### PR TITLE
Rollback to view behaviour for loc and iloc.

### DIFF
--- a/gensor/core/base.py
+++ b/gensor/core/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from copy import deepcopy
 from typing import Any, Literal, TypeVar
 
 import pandas as pd
@@ -107,7 +108,9 @@ class BaseTimeseries(pyd.BaseModel):
                     result = ts_attr(*args, **kwargs)
                     # If the result is a Series, return a new Timeseries; otherwise, return the result
                     if isinstance(result, pd.Series):
-                        return self.model_copy(update={"ts": result}, deep=True)
+                        return self.model_copy(
+                            update={"ts": deepcopy(result)}, deep=True
+                        )
 
                     return result
 

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -36,6 +36,10 @@ class Dataset(pyd.BaseModel, Generic[T]):
     def __getitem__(self, index: int) -> T | None:
         """Retrieve a Timeseries object by its index in the dataset.
 
+        !!! warning
+            Using index will return the reference to the timeseries. If you need a copy,
+            use .filter() instead of Dataset[index]
+
         Parameters:
             index (int): The index of the Timeseries to retrieve.
 
@@ -46,7 +50,7 @@ class Dataset(pyd.BaseModel, Generic[T]):
             IndexError: If the index is out of range.
         """
         try:
-            return self.timeseries[index].model_copy(deep=True)
+            return self.timeseries[index]
         except IndexError:
             raise IndexOutOfRangeError(index, len(self)) from None
 

--- a/gensor/core/indexer.py
+++ b/gensor/core/indexer.py
@@ -18,12 +18,12 @@ class TimeseriesIndexer:
         self.indexer = indexer
 
     def __getitem__(self, key: str) -> Any:
-        """Allows using the indexer (e.g., loc) and wraps the result in a Timeseries."""
+        """Allows using the indexer (e.g., loc) and wraps the result in the parent Timeseries."""
 
         result = self.indexer[key]
 
         if isinstance(result, pd.Series):
-            return self.parent.model_copy(update={"ts": result}, deep=True)
+            return self.parent.model_copy(update={"ts": result}, deep=False)
 
         if isinstance(result, (int | float | str | pd.Timestamp | np.float64)):
             return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gensor"
-version = "0.2.3"
+version = "0.2.4"
 description = "Library for handling groundwater sensor data."
 authors = ["Mateusz Zawadzki <zawadzkimat@outlook.com>"]
 repository = "https://github.com/zawadzkim/gensor"


### PR DESCRIPTION
Now the iloc and loc accessors on Timeseries and Dataset return references to the objects and not deep copies of the object.