### PR TITLE
Release 0.4.0 — filtering (~/Where), pop, info, faceted plots, Dataset.loc, water_column; compensation cutoff fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,49 +1,25 @@
 # Changelog
 
-All notable changes to gensor are documented here. This project adheres to
-[Semantic Versioning](https://semver.org/).
+All notable changes to gensor are documented here. This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.4.0]
 
 ### Added
 
-- **`Dataset.filter` negation and predicates.** A leading `~` on any value negates it
-  (`filter(location="~PB16D")` drops that location); positive and negated values may be
-  mixed within an attribute and across attributes. For conditions the per-attribute
-  keywords can't express, a composable `Where` predicate (`&`, `|`, `~`) can be passed
-  positionally, e.g. `filter(~Where(location="PB03B", sensor="AV319"))` to drop only that
-  sensor at that location.
-- **`Dataset.pop(...)`** — same selection as `filter`, but removes the matched timeseries
-  from the dataset and returns them by reference, for an extract → edit → `add()`
-  round-trip.
-- **`Dataset.info`** — a per-timeseries metadata table (location, variable, sensor,
-  records, start, end). It is now the single source for the per-series summary used by
-  `Dataset.coverage` (which adds a derived `duration`) and `gensor.diff` / `CoverageDiff`.
-- **`Dataset.coverage`** — coverage summary that renders as a table and offers
-  `.plot()` for a per-location coverage timeline (bars broken on gaps > `max_gap`).
-- **`gensor.diff` / `Dataset.diff`** — coverage comparison of two or more datasets,
-  aligned by key, rendering as a wide table with a `.plot()` N-way timeline.
-- **`Dataset.plot(facet="location", ...)`** — a grid of one panel per location (a separate
-  figure per variable), with `ncols`, `sharex` (align all panels to the full time span),
-  per-panel legends only when several sensors share a panel (labelled by serial), and the
-  compact grid styling. `facet="variable"` (overlaid locations) remains the default.
-- **`Dataset.loc[start:end]`** — label-based selection forwarded to every timeseries,
-  returning a new sliced Dataset.
-- **`water_column(...)`** (and `Compensator.water_column`) — the barometric-compensation
-  step exposed on its own: it returns the water column above the sensor (m) without adding
-  the sensor altitude. `compensate(...)` now builds on it.
-- Parser reads location/serial from labelled Diver-Office header fields; `Dataset`
-  supports `(location, variable[, unit])` tuple indexing, `__contains__`, and `one()`.
+- `Dataset.filter` value negation: a leading `~` drops matches (e.g. `filter(location="~PB16D")`); positive and negated values may be mixed within and across attributes.
+- `Where` predicate (`&`, `|`, `~`) for combined/cross-attribute conditions, e.g. `filter(~Where(location="PB03B", sensor="AV319"))` drops only that sensor at that location.
+- `Dataset.pop(...)`: same selection as `filter`, but removes the matches and returns them by reference for an extract → edit → `add()` round-trip.
+- `Dataset.info`: per-timeseries metadata table (location, variable, sensor, records, start, end); now the single source for `Dataset.coverage` (which adds a derived `duration`) and `gensor.diff` / `CoverageDiff`.
+- `Dataset.coverage`: coverage summary that renders as a table and offers `.plot()` for a per-location coverage timeline.
+- `gensor.diff` / `Dataset.diff`: coverage comparison of two or more datasets, with a wide table and an N-way timeline `.plot()`.
+- `Dataset.plot(facet="location", ncols=, sharex=)`: a grid of one panel per location (a separate figure per variable); empty locations keep an empty panel; per-panel legend (by sensor serial) only when several sensors share a panel. `facet="variable"` remains the default.
+- `Dataset.loc[start:end]`: label slicing forwarded to every timeseries, returning a new sliced Dataset.
+- `water_column(...)` and `Compensator.water_column`: the barometric-compensation step on its own (water column above the sensor, in metres), without adding the sensor altitude; `compensate(...)` now builds on it.
+- Parser reads location/serial from labelled Diver-Office header fields; `Dataset` supports `(location, variable[, unit])` tuple indexing, `__contains__`, and `one()`.
 
 ### Changed
 
-- **Compensation out-of-water filtering is now a signed cutoff and always applied.**
-  The water column above a submerged sensor is physically non-negative, so negative values
-  are always dropped and the near-zero out-of-water band at or below `threshold_wc` is
-  removed. `threshold_wc` now defaults to `0.025` m (25 mm); set a smaller value to keep
-  shallower columns, or `0` to drop only negatives. (Previously the cutoff compared the
-  *absolute* value, which wrongly retained large-magnitude negatives, and was off by
-  default.)
+- Compensation out-of-water filtering is now a signed cutoff and always applied. Negative water columns are always dropped (physically impossible for a submerged sensor) and the near-zero band at or below `threshold_wc` is removed. `threshold_wc` now defaults to `0.025` m (25 mm); set a smaller value to keep shallower columns, or `0` to drop only negatives. Previously the cutoff compared the absolute value, wrongly retaining large-magnitude negatives, and was off by default.
 
 ### Fixed
 
@@ -51,5 +27,4 @@ All notable changes to gensor are documented here. This project adheres to
 
 ### Removed
 
-- The `exclude=` dict argument of `Dataset.filter` — superseded by `~` negation and
-  `Where` predicates.
+- The `exclude=` dict argument of `Dataset.filter`, superseded by `~` negation and `Where` predicates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to gensor are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.4.0]
+
+### Added
+
+- **`Dataset.filter` negation and predicates.** A leading `~` on any value negates it
+  (`filter(location="~PB16D")` drops that location); positive and negated values may be
+  mixed within an attribute and across attributes. For conditions the per-attribute
+  keywords can't express, a composable `Where` predicate (`&`, `|`, `~`) can be passed
+  positionally, e.g. `filter(~Where(location="PB03B", sensor="AV319"))` to drop only that
+  sensor at that location.
+- **`Dataset.pop(...)`** — same selection as `filter`, but removes the matched timeseries
+  from the dataset and returns them by reference, for an extract → edit → `add()`
+  round-trip.
+- **`Dataset.info`** — a per-timeseries metadata table (location, variable, sensor,
+  records, start, end). It is now the single source for the per-series summary used by
+  `Dataset.coverage` (which adds a derived `duration`) and `gensor.diff` / `CoverageDiff`.
+- **`Dataset.coverage`** — coverage summary that renders as a table and offers
+  `.plot()` for a per-location coverage timeline (bars broken on gaps > `max_gap`).
+- **`gensor.diff` / `Dataset.diff`** — coverage comparison of two or more datasets,
+  aligned by key, rendering as a wide table with a `.plot()` N-way timeline.
+- **`Dataset.plot(facet="location", ...)`** — a grid of one panel per location (a separate
+  figure per variable), with `ncols`, `sharex` (align all panels to the full time span),
+  per-panel legends only when several sensors share a panel (labelled by serial), and the
+  compact grid styling. `facet="variable"` (overlaid locations) remains the default.
+- **`Dataset.loc[start:end]`** — label-based selection forwarded to every timeseries,
+  returning a new sliced Dataset.
+- **`water_column(...)`** (and `Compensator.water_column`) — the barometric-compensation
+  step exposed on its own: it returns the water column above the sensor (m) without adding
+  the sensor altitude. `compensate(...)` now builds on it.
+- Parser reads location/serial from labelled Diver-Office header fields; `Dataset`
+  supports `(location, variable[, unit])` tuple indexing, `__contains__`, and `one()`.
+
+### Changed
+
+- **Compensation out-of-water filtering is now a signed cutoff and always applied.**
+  The water column above a submerged sensor is physically non-negative, so negative values
+  are always dropped and the near-zero out-of-water band at or below `threshold_wc` is
+  removed. `threshold_wc` now defaults to `0.025` m (25 mm); set a smaller value to keep
+  shallower columns, or `0` to drop only negatives. (Previously the cutoff compared the
+  *absolute* value, which wrongly retained large-magnitude negatives, and was off by
+  default.)
+
+### Fixed
+
+- `Dataset.to_sql` made robust; van Essen parser made robust.
+
+### Removed
+
+- The `exclude=` dict argument of `Dataset.filter` — superseded by `~` negation and
+  `Where` predicates.

--- a/gensor/__init__.py
+++ b/gensor/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from .core.dataset import Dataset
+from .core.dataset import Dataset, diff
 from .core.timeseries import Timeseries
 from .io.read import read_from_csv, read_from_sql
 from .log import set_log_level
@@ -11,6 +11,8 @@ __all__ = [
     "Dataset",
     "Timeseries",
     "compensate",
+    # comparison
+    "diff",
     # getters
     "read_from_csv",
     "read_from_sql",

--- a/gensor/__init__.py
+++ b/gensor/__init__.py
@@ -1,16 +1,18 @@
 import logging
 
-from .core.dataset import Dataset, diff
+from .core.dataset import Dataset, Where, diff
 from .core.timeseries import Timeseries
 from .io.read import read_from_csv, read_from_sql
 from .log import set_log_level
-from .processing.compensation import compensate
+from .processing.compensation import compensate, water_column
 
 __all__ = [
     # basic data types
     "Dataset",
     "Timeseries",
+    "Where",
     "compensate",
+    "water_column",
     # comparison
     "diff",
     # getters

--- a/gensor/core/base.py
+++ b/gensor/core/base.py
@@ -304,9 +304,18 @@ class BaseTimeseries(pyd.BaseModel):
             message = "The index is not a DatetimeIndex and cannot be converted to UTC."
             raise TypeError(message)
 
-        series_as_records = list(
-            zip(utc_index.strftime("%Y-%m-%dT%H:%M:%S%z"), self.ts, strict=False)
-        )
+        # Records as dicts keyed by column name so the insert can run as an
+        # executemany (one row per parameter set) instead of a single multi-row
+        # VALUES clause - the latter blows SQLite's bound-variable limit for long
+        # series. ``tolist()`` also yields native Python floats/strings.
+        series_as_records = [
+            {"timestamp": timestamp, self.variable: value}
+            for timestamp, value in zip(
+                utc_index.strftime("%Y-%m-%dT%H:%M:%S%z").tolist(),
+                self.ts.tolist(),
+                strict=False,
+            )
+        ]
 
         # Extra metadata are attributes additional to BaseTimeseries
         core_metadata, extra_metadata = separate_metadata()
@@ -340,9 +349,11 @@ class BaseTimeseries(pyd.BaseModel):
             metadata_entry.update({"table_name": schema_name})
 
             if isinstance(schema, Table):
-                stmt = sqlite_insert(schema).values(series_as_records)
-                stmt = stmt.on_conflict_do_nothing(index_elements=["timestamp"])
-                con.execute(stmt)
+                if series_as_records:
+                    stmt = sqlite_insert(schema).on_conflict_do_nothing(
+                        index_elements=["timestamp"]
+                    )
+                    con.execute(stmt, series_as_records)
 
                 metadata_stmt = sqlite_insert(metadata_schema).values(metadata_entry)
                 metadata_stmt = metadata_stmt.on_conflict_do_update(

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -162,49 +162,67 @@ class Dataset(pyd.BaseModel, Generic[T]):
         location: str | list | None = None,
         variable: str | list | None = None,
         unit: str | list | None = None,
-        **kwargs: dict[str, str | list],
+        exclude: dict[str, str | list] | None = None,
+        **kwargs: str | list,
     ) -> T | Dataset:
         """Return a Timeseries or a new Dataset filtered by station, sensor,
         and/or variable.
 
+        Any of ``location``/``variable``/``unit`` (and the keyword attributes) may be
+        a single value or a list of values, matching a timeseries when its attribute
+        equals (or is in) the given value(s).
+
+        To filter by the *opposite* - dropping timeseries rather than selecting them -
+        pass ``exclude``, a dict of ``{attribute: value | list}``. A timeseries is
+        removed when it matches **all** conditions in ``exclude`` (e.g.
+        ``exclude={"location": "PB16D"}`` drops that location, while
+        ``exclude={"location": "PB03B", "sensor": "AV319"}`` drops only that one
+        sensor at that location). ``exclude`` is applied after the include filters.
+
         Parameters:
-            location (Optional[str]): The location name.
-            variable (Optional[str]): The variable being measured.
-            unit (Optional[str]): Unit of the measurement.
-            **kwargs (dict): Attributes of subclassed timeseries used for filtering
-                (e.g., sensor, method).
+            location (str | list, optional): The location name(s).
+            variable (str | list, optional): The variable(s) being measured.
+            unit (str | list, optional): Unit(s) of the measurement.
+            exclude (dict, optional): ``{attribute: value | list}`` conditions whose
+                (combined) match removes a timeseries from the result.
+            **kwargs (str | list): Attributes of subclassed timeseries used for
+                filtering (e.g., sensor, method).
 
         Returns:
             Timeseries | Dataset: A single Timeseries if exactly one match is found,
                                    or a new Dataset if multiple matches are found.
         """
 
-        def matches(ts: T, attr: str, value: dict[str, str | list]) -> bool | None:
-            """Check if the Timeseries object has the attribute and if it matches the value."""
+        def as_list(value: str | list | None) -> list | None:
+            return [value] if isinstance(value, str) else value
+
+        def matches(ts: T, attr: str, value: list) -> bool:
+            """Check the Timeseries has the attribute and its value is in ``value``."""
             if not hasattr(ts, attr):
                 message = f"'{ts.__class__.__name__}' object has no attribute '{attr}'"
                 raise AttributeError(message)
             return getattr(ts, attr) in value
 
-        if isinstance(location, str):
-            location = [location]
-        if isinstance(variable, str):
-            variable = [variable]
-        if isinstance(unit, str):
-            unit = [unit]
-        for key, value in kwargs.items():
-            if isinstance(value, str):
-                kwargs[key] = [value]
+        location, variable, unit = as_list(location), as_list(variable), as_list(unit)
+        kwargs = {attr: as_list(value) for attr, value in kwargs.items()}
+        exclude = {attr: as_list(value) for attr, value in (exclude or {}).items()}
 
-        matching_timeseries = [
-            ts
-            for ts in self.timeseries
-            if ts is not None
-            and (location is None or ts.location in location)
-            and (variable is None or ts.variable in variable)
-            and (unit is None or ts.unit in unit)
-            and all(matches(ts, attr, value) for attr, value in kwargs.items())
-        ]
+        def keep(ts: T | None) -> bool:
+            if ts is None:
+                return False
+            if location is not None and ts.location not in location:
+                return False
+            if variable is not None and ts.variable not in variable:
+                return False
+            if unit is not None and ts.unit not in unit:
+                return False
+            if not all(matches(ts, attr, value) for attr, value in kwargs.items()):
+                return False
+            if exclude and all(matches(ts, attr, value) for attr, value in exclude.items()):
+                return False
+            return True
+
+        matching_timeseries = [ts for ts in self.timeseries if keep(ts)]
 
         if not matching_timeseries:
             return Dataset()

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -599,7 +599,7 @@ class Dataset(pyd.BaseModel, Generic[T]):
         ax.tick_params(labelsize=6)
         for label in ax.get_xticklabels():
             label.set_rotation(45)
-            label.set_ha("right")
+            label.set_horizontalalignment("right")
         if len(series) > 1:  # only label sensors when they share a panel
             ax.legend(**legend_kwargs)
 

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -33,30 +33,48 @@ class Dataset(pyd.BaseModel, Generic[T]):
     def __repr__(self) -> str:
         return f"Dataset({len(self)})"
 
-    def __getitem__(self, index: int) -> T | None:
-        """Retrieve a Timeseries object by its index in the dataset.
+    def __getitem__(self, key: int | str | list) -> T | None | Dataset:
+        """Retrieve Timeseries by integer index or by location name.
+
+        - ``dataset[0]`` returns the Timeseries at that position (a reference).
+        - ``dataset["PB01A"]`` returns the Timeseries at that location, or a
+          Dataset if the location has several timeseries (e.g. pressure and
+          temperature). A list of names (``dataset[["PB01A", "PB02A"]]``) always
+          returns a Dataset.
 
         !!! warning
-            Using index will return the reference to the timeseries. If you need a copy,
-            use .filter() instead of Dataset[index]
+            Integer indexing returns a reference to the timeseries. Location
+            indexing returns copies (it delegates to ``.filter()``).
 
         Parameters:
-            index (int): The index of the Timeseries to retrieve.
+            key (int | str | list): Position, location name, or list of names.
 
         Returns:
-            Timeseries: The Timeseries object at the specified index.
+            Timeseries | Dataset: The matching timeseries or a dataset of them.
 
         Raises:
-            IndexError: If the index is out of range.
+            IndexOutOfRangeError: If an integer index is out of range.
+            KeyError: If no timeseries matches the given location(s).
         """
+        if isinstance(key, (str, list)):
+            result = self.filter(location=key)
+            if isinstance(result, Dataset) and len(result) == 0:
+                message = f"No timeseries found for location(s) {key!r}."
+                raise KeyError(message)
+            return result
+
         try:
-            return self.timeseries[index]
+            return self.timeseries[key]
         except IndexError:
-            raise IndexOutOfRangeError(index, len(self)) from None
+            raise IndexOutOfRangeError(key, len(self)) from None
 
     def get_locations(self) -> list:
-        """List all unique locations in the dataset."""
-        return [ts.location for ts in self.timeseries if ts is not None]
+        """List all unique locations in the dataset, preserving first-seen order."""
+        locations: list = []
+        for ts in self.timeseries:
+            if ts is not None and ts.location not in locations:
+                locations.append(ts.location)
+        return locations
 
     def add(self, other: T | list[T] | Dataset) -> Dataset:
         """Appends new Timeseries to the Dataset.

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Generic
+from typing import Any, ClassVar, Generic
 
 import pandas as pd
 import pydantic as pyd
@@ -28,7 +28,9 @@ def _split(value: str | list | None) -> tuple[set, set]:
     include: set = set()
     exclude: set = set()
     for v in values:
-        (exclude if v.startswith("~") else include).add(v[1:] if v.startswith("~") else v)
+        (exclude if v.startswith("~") else include).add(
+            v[1:] if v.startswith("~") else v
+        )
     return include, exclude
 
 
@@ -60,7 +62,9 @@ class Where:
         def test(ts: Any) -> bool:
             for attr, (include, exclude) in specs.items():
                 if not hasattr(ts, attr):
-                    message = f"'{ts.__class__.__name__}' object has no attribute '{attr}'"
+                    message = (
+                        f"'{ts.__class__.__name__}' object has no attribute '{attr}'"
+                    )
                     raise AttributeError(message)
                 actual = getattr(ts, attr)
                 if (include and actual not in include) or actual in exclude:
@@ -171,7 +175,7 @@ class Dataset(pyd.BaseModel, Generic[T]):
                 raise KeyError(message)
             return result
 
-        if isinstance(key, (str, list)):
+        if isinstance(key, str | list):
             result = self.filter(location=key)
             if isinstance(result, Dataset) and len(result) == 0:
                 message = f"No timeseries found for location(s) {key!r}."
@@ -185,9 +189,7 @@ class Dataset(pyd.BaseModel, Generic[T]):
 
     def __contains__(self, location: object) -> bool:
         """Return True if any timeseries in the dataset has the given location."""
-        return any(
-            ts is not None and ts.location == location for ts in self.timeseries
-        )
+        return any(ts is not None and ts.location == location for ts in self.timeseries)
 
     def get_locations(self) -> list:
         """List all unique locations in the dataset, preserving first-seen order."""
@@ -253,7 +255,9 @@ class Dataset(pyd.BaseModel, Generic[T]):
             columns=columns,
         )
         if not table.empty:
-            table = table.sort_values(["location", "variable", "sensor"]).reset_index(drop=True)
+            table = table.sort_values(["location", "variable", "sensor"]).reset_index(
+                drop=True
+            )
         return table
 
     def diff(
@@ -449,7 +453,11 @@ class Dataset(pyd.BaseModel, Generic[T]):
         match.
         """
         keywords = {"location": location, "variable": variable, "unit": unit, **kwargs}
-        tests = [Where(**{attr: value}) for attr, value in keywords.items() if value is not None]
+        tests = [
+            Where(**{attr: value})
+            for attr, value in keywords.items()
+            if value is not None
+        ]
         tests.extend(predicates)
 
         def keep(ts: T | None) -> bool:
@@ -523,65 +531,115 @@ class Dataset(pyd.BaseModel, Generic[T]):
         )
 
         if facet == "variable":
-            fig, axes = plt.subplots(
-                len(variables), 1, figsize=(10, 5 * len(variables)), sharex=True, squeeze=False
+            return self._plot_by_variable(
+                variables, include_outliers, plot_kwargs, legend_kwargs
             )
-            axes = list(axes.ravel())
-            for ax, var in zip(axes, variables, strict=False):
-                for ts in self.timeseries:
-                    if ts is not None and ts.variable == var and len(ts.ts) > 0:
-                        ts.plot(
-                            include_outliers=include_outliers,
-                            ax=ax,
-                            plot_kwargs=plot_kwargs,
-                            legend_kwargs=legend_kwargs,
-                        )
-                ax.set_title(f"Timeseries for {var.capitalize()}")
-                ax.set_xlabel("Time")
-            fig.tight_layout()
-            return fig, axes
-
         if facet == "location":
-            locations = self.get_locations()
-            nrows = (len(locations) + ncols - 1) // ncols if locations else 1
-            pkw = {"lw": 0.7, **(plot_kwargs or {})}
-            lkw = {"fontsize": 7, **(legend_kwargs or {})}
-            results: dict[str, tuple[Figure, list]] = {}
-            for var in variables:
-                fig, axs = plt.subplots(
-                    nrows, ncols, figsize=(4 * ncols, 2.3 * nrows), squeeze=False, sharex=sharex
-                )
-                axes = list(axs.ravel())
-                for ax, loc in zip(axes, locations, strict=False):
-                    series = [
-                        ts
-                        for ts in self.timeseries
-                        if ts is not None
-                        and ts.location == loc
-                        and ts.variable == var
-                        and len(ts.ts) > 0
-                    ]
-                    for ts in series:
-                        ax.plot(ts.ts.index, ts.ts.to_numpy(), label=ts.sensor, **pkw)
-                        if include_outliers and ts.outliers is not None and len(ts.outliers) > 0:
-                            ax.scatter(ts.outliers.index, ts.outliers, color="red", s=5)
-                    ax.set_title(loc, fontsize=8)  # every location keeps a panel, even if empty
-                    ax.tick_params(labelsize=6)
-                    for label in ax.get_xticklabels():
-                        label.set_rotation(45)
-                        label.set_ha("right")
-                    # only worth a legend when sensors share a panel; label them by serial
-                    if len(series) > 1:
-                        ax.legend(**lkw)
-                for ax in axes[len(locations):]:
-                    ax.set_visible(False)  # hide unused trailing cells
-                fig.suptitle(f"{var.capitalize()} by location", fontsize=13)
-                fig.tight_layout(rect=(0, 0, 1, 0.98))  # leave room for the suptitle
-                results[var] = (fig, axes)
-            return results
+            return self._plot_by_location(
+                variables, ncols, sharex, include_outliers, plot_kwargs, legend_kwargs
+            )
 
         message = f"facet must be 'variable' or 'location', got {facet!r}."
         raise ValueError(message)
+
+    def _plot_by_variable(
+        self,
+        variables: list,
+        include_outliers: bool,
+        plot_kwargs: dict[str, Any] | None,
+        legend_kwargs: dict[str, Any] | None,
+    ) -> tuple[Figure, list]:
+        """One subplot per variable, every location overlaid (see :meth:`plot`)."""
+        fig, axs = plt.subplots(
+            len(variables),
+            1,
+            figsize=(10, 5 * len(variables)),
+            sharex=True,
+            squeeze=False,
+        )
+        axes = list(axs.ravel())
+        for ax, var in zip(axes, variables, strict=False):
+            for ts in self.timeseries:
+                if ts is not None and ts.variable == var and len(ts.ts) > 0:
+                    ts.plot(
+                        include_outliers=include_outliers,
+                        ax=ax,
+                        plot_kwargs=plot_kwargs,
+                        legend_kwargs=legend_kwargs,
+                    )
+            ax.set_title(f"Timeseries for {var.capitalize()}")
+            ax.set_xlabel("Time")
+        fig.tight_layout()
+        return fig, axes
+
+    def _series_at(self, location: str, variable: str) -> list:
+        """Non-empty timeseries at a given location and variable."""
+        return [
+            ts
+            for ts in self.timeseries
+            if ts is not None
+            and ts.location == location
+            and ts.variable == variable
+            and len(ts.ts) > 0
+        ]
+
+    def _draw_location_panel(
+        self,
+        ax: Axes,
+        series: list,
+        include_outliers: bool,
+        plot_kwargs: dict[str, Any],
+        legend_kwargs: dict[str, Any],
+    ) -> None:
+        """Draw one location panel: overlay its series, style ticks, legend if shared."""
+        for ts in series:
+            ax.plot(ts.ts.index, ts.ts.to_numpy(), label=ts.sensor, **plot_kwargs)
+            if include_outliers and ts.outliers is not None and len(ts.outliers) > 0:
+                ax.scatter(ts.outliers.index, ts.outliers, color="red", s=5)
+        ax.tick_params(labelsize=6)
+        for label in ax.get_xticklabels():
+            label.set_rotation(45)
+            label.set_ha("right")
+        if len(series) > 1:  # only label sensors when they share a panel
+            ax.legend(**legend_kwargs)
+
+    def _plot_by_location(
+        self,
+        variables: list,
+        ncols: int,
+        sharex: bool,
+        include_outliers: bool,
+        plot_kwargs: dict[str, Any] | None,
+        legend_kwargs: dict[str, Any] | None,
+    ) -> dict[str, tuple[Figure, list]]:
+        """A grid of one panel per location, a figure per variable (see :meth:`plot`)."""
+        locations = self.get_locations()
+        nrows = (len(locations) + ncols - 1) // ncols if locations else 1
+        pkw = {"lw": 0.7, **(plot_kwargs or {})}
+        lkw = {"fontsize": 7, **(legend_kwargs or {})}
+        results: dict[str, tuple[Figure, list]] = {}
+        for var in variables:
+            fig, axs = plt.subplots(
+                nrows,
+                ncols,
+                figsize=(4 * ncols, 2.3 * nrows),
+                squeeze=False,
+                sharex=sharex,
+            )
+            axes = list(axs.ravel())
+            for ax, loc in zip(axes, locations, strict=False):
+                ax.set_title(
+                    loc, fontsize=8
+                )  # every location keeps a panel, even if empty
+                self._draw_location_panel(
+                    ax, self._series_at(loc, var), include_outliers, pkw, lkw
+                )
+            for ax in axes[len(locations) :]:
+                ax.set_visible(False)  # hide unused trailing cells
+            fig.suptitle(f"{var.capitalize()} by location", fontsize=13)
+            fig.tight_layout(rect=(0, 0, 1, 0.98))  # leave room for the suptitle
+            results[var] = (fig, axes)
+        return results
 
 
 def _coverage_segments(index: pd.DatetimeIndex, threshold: pd.Timedelta) -> list[tuple]:
@@ -615,7 +673,15 @@ class Coverage:
     the per-series summary has a single source.
     """
 
-    columns = ["location", "variable", "sensor", "records", "start", "end", "duration"]
+    columns: ClassVar[list[str]] = [
+        "location",
+        "variable",
+        "sensor",
+        "records",
+        "start",
+        "end",
+        "duration",
+    ]
 
     def __init__(self, dataset: Dataset) -> None:
         self._dataset = dataset
@@ -657,14 +723,16 @@ class Coverage:
             fig = ax.figure
 
         for row, location in enumerate(locations):
-            index = None
+            index: pd.DatetimeIndex | None = None
             for ts in self._dataset:
                 if ts is None or ts.location != location or len(ts.ts) == 0:
                     continue
                 index = ts.ts.index if index is None else index.union(ts.ts.index)
             if index is None or len(index) == 0:
                 continue
-            ax.broken_barh(_coverage_segments(index, threshold), (row - 0.4, 0.8), facecolors=color)
+            ax.broken_barh(
+                _coverage_segments(index, threshold), (row - 0.4, 0.8), facecolors=color
+            )
 
         ax.set_yticks(range(len(locations)))
         ax.set_yticklabels(locations, fontsize=8)
@@ -713,9 +781,13 @@ class CoverageDiff:
                     continue
                 k = tuple(getattr(ts, attr) for attr in self.key)
                 index_by_key[k] = (
-                    ts.ts.index if k not in index_by_key else index_by_key[k].union(ts.ts.index)
+                    ts.ts.index
+                    if k not in index_by_key
+                    else index_by_key[k].union(ts.ts.index)
                 )
-            self._index[label] = {k: idx.sort_values() for k, idx in index_by_key.items()}
+            self._index[label] = {
+                k: idx.sort_values() for k, idx in index_by_key.items()
+            }
 
         self.keys = sorted({k for cov in self._coverage.values() for k in cov})
         self.table = self._build_table()
@@ -764,7 +836,8 @@ class CoverageDiff:
             cov = self._coverage[label]
             for metric in ("sensor", "records", "start", "end"):
                 data[(label, metric)] = [
-                    cov.get(k, defaults).get(metric, defaults[metric]) for k in self.keys
+                    cov.get(k, defaults).get(metric, defaults[metric])
+                    for k in self.keys
                 ]
         data[("summary", "present")] = [
             sum(k in self._coverage[lab] for lab in self.labels) for k in self.keys
@@ -862,7 +935,9 @@ def diff(
         CoverageDiff: renders as a comparison table; ``.plot()`` draws the timeline.
     """
     if isinstance(datasets, Dataset):
-        message = "Pass two or more datasets to diff(), e.g. diff({'a': ds1, 'b': ds2})."
+        message = (
+            "Pass two or more datasets to diff(), e.g. diff({'a': ds1, 'b': ds2})."
+        )
         raise TypeError(message)
     if not isinstance(datasets, dict):
         datasets = {f"ds{i}": d for i, d in enumerate(datasets)}

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from typing import Any, Generic
 
@@ -11,6 +12,8 @@ from matplotlib.figure import Figure
 from gensor.core.base import BaseTimeseries, T
 from gensor.db import DatabaseConnection
 from gensor.exceptions import IndexOutOfRangeError
+
+logger = logging.getLogger(__name__)
 
 
 class Dataset(pyd.BaseModel, Generic[T]):
@@ -68,6 +71,12 @@ class Dataset(pyd.BaseModel, Generic[T]):
         except IndexError:
             raise IndexOutOfRangeError(key, len(self)) from None
 
+    def __contains__(self, location: object) -> bool:
+        """Return True if any timeseries in the dataset has the given location."""
+        return any(
+            ts is not None and ts.location == location for ts in self.timeseries
+        )
+
     def get_locations(self) -> list:
         """List all unique locations in the dataset, preserving first-seen order."""
         locations: list = []
@@ -75,6 +84,32 @@ class Dataset(pyd.BaseModel, Generic[T]):
             if ts is not None and ts.location not in locations:
                 locations.append(ts.location)
         return locations
+
+    def one(self, **filters: Any) -> T:
+        """Return exactly one matching Timeseries.
+
+        A convenience over :meth:`filter` for when a single result is expected:
+        it always returns a Timeseries (never a Dataset) and raises if zero or
+        more than one timeseries match - avoiding the "is it a Timeseries or a
+        Dataset?" ambiguity of :meth:`filter` / ``dataset[name]``.
+
+        Parameters:
+            **filters: Same keyword filters as :meth:`filter` (location,
+                variable, unit, sensor, ...).
+
+        Returns:
+            Timeseries: The single matching timeseries.
+
+        Raises:
+            ValueError: If zero or more than one timeseries match the filters.
+        """
+        result = self.filter(**filters)
+        if isinstance(result, BaseTimeseries):
+            return result
+
+        count = len(result)
+        message = f"Expected exactly one timeseries matching {filters}, found {count}."
+        raise ValueError(message)
 
     def add(self, other: T | list[T] | Dataset) -> Dataset:
         """Appends new Timeseries to the Dataset.
@@ -173,8 +208,15 @@ class Dataset(pyd.BaseModel, Generic[T]):
             db (DatabaseConnection): SQLite database connection object.
         """
         for ts in self.timeseries:
-            if ts:
-                ts.to_sql(db)
+            if ts is None:
+                continue
+            if len(ts.ts) == 0:
+                logger.info(
+                    f"Skipping empty timeseries (location={ts.location!r}) - "
+                    "nothing to write to the database."
+                )
+                continue
+            ts.to_sql(db)
         return
 
     def plot(

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from typing import Any, Generic
 
 import pandas as pd
@@ -15,6 +14,105 @@ from gensor.db import DatabaseConnection
 from gensor.exceptions import IndexOutOfRangeError
 
 logger = logging.getLogger(__name__)
+
+
+def _split(value: str | list | None) -> tuple[set, set]:
+    """Split an attribute spec into (include, exclude) value sets.
+
+    A leading ``~`` on a string value moves it to the exclude set; ``None`` (or an
+    empty spec) constrains nothing. Shared by ``Dataset.filter`` and ``Where``.
+    """
+    if value is None:
+        return set(), set()
+    values = [value] if isinstance(value, str) else value
+    include: set = set()
+    exclude: set = set()
+    for v in values:
+        (exclude if v.startswith("~") else include).add(v[1:] if v.startswith("~") else v)
+    return include, exclude
+
+
+class Where:
+    """A composable predicate over a Timeseries' attributes, for ``Dataset.filter``/``drop``.
+
+    A leaf ``Where(**conditions)`` matches a Timeseries when **every** condition holds;
+    each condition matches when the timeseries' attribute equals (or is in, for a list)
+    the given value(s), and a leading ``~`` on a value negates that single condition.
+    Compose leaves with ``&`` (and), ``|`` (or) and ``~`` (not) to express anything the
+    per-attribute keyword filters can't - in particular a *combined* exclusion::
+
+        ~Where(location="PB03B", sensor="AV319")            # not (PB03B and AV319)
+        Where(variable="pressure") & ~Where(location="PB16D")
+        Where(location="PB16A") | Where(location="PB16B")
+
+    Pass instances straight to ``Dataset.filter`` (keep matches) or ``Dataset.drop``
+    (remove matches); they are AND-ed with the keyword filters in the same call.
+    """
+
+    def __init__(self, _test: Any = None, **conditions: str | list) -> None:
+        self._conditions = conditions
+        self._test = _test if _test is not None else self._compile(conditions)
+
+    @staticmethod
+    def _compile(conditions: dict) -> Any:
+        specs = {attr: _split(value) for attr, value in conditions.items()}
+
+        def test(ts: Any) -> bool:
+            for attr, (include, exclude) in specs.items():
+                if not hasattr(ts, attr):
+                    message = f"'{ts.__class__.__name__}' object has no attribute '{attr}'"
+                    raise AttributeError(message)
+                actual = getattr(ts, attr)
+                if (include and actual not in include) or actual in exclude:
+                    return False
+            return True
+
+        return test
+
+    def __call__(self, ts: Any) -> bool:
+        return bool(self._test(ts))
+
+    def __invert__(self) -> Where:
+        return Where(_test=lambda ts: not self._test(ts))
+
+    def __and__(self, other: Where) -> Where:
+        return Where(_test=lambda ts: self._test(ts) and other(ts))
+
+    def __or__(self, other: Where) -> Where:
+        return Where(_test=lambda ts: self._test(ts) or other(ts))
+
+    def __repr__(self) -> str:
+        body = ", ".join(f"{k}={v!r}" for k, v in self._conditions.items())
+        return f"Where({body})"
+
+
+class DatasetIndexer:
+    """Applies a pandas ``.loc`` selection to every Timeseries in a Dataset.
+
+    Returned by :attr:`Dataset.loc`. ``ds.loc[start:end]`` slices each timeseries by label
+    (e.g. a date range) via its own ``.loc`` and returns a new Dataset of the results.
+    Intended for label slices; a key that selects a single scalar from a timeseries (a
+    point lookup) is rejected, since the per-series scalars can't form a Dataset.
+    """
+
+    def __init__(self, parent: Dataset) -> None:
+        self.parent = parent
+
+    def __getitem__(self, key: Any) -> Dataset:
+        sliced: list = []
+        for ts in self.parent.timeseries:
+            if ts is None:
+                sliced.append(None)
+                continue
+            result = ts.loc[key]
+            if not isinstance(result, BaseTimeseries):
+                message = (
+                    "Dataset.loc expects a label slice (e.g. ds.loc[start:end]); "
+                    f"key {key!r} selected a scalar from a timeseries."
+                )
+                raise TypeError(message)
+            sliced.append(result)
+        return self.parent.model_copy(update={"timeseries": sliced}, deep=False)
 
 
 class Dataset(pyd.BaseModel, Generic[T]):
@@ -100,6 +198,19 @@ class Dataset(pyd.BaseModel, Generic[T]):
         return locations
 
     @property
+    def loc(self) -> DatasetIndexer:
+        """Label-based selection applied to every timeseries in the dataset.
+
+        ``ds.loc[start:end]`` returns a new Dataset where each timeseries is sliced by
+        ``.loc[start:end]`` (e.g. a date range), forwarding the key to each series' own
+        pandas ``.loc``. Empty slices yield empty timeseries (every series is kept).
+
+        Examples:
+            >>> ds.loc["2021-01-01":"2021-12-31"]  # doctest: +SKIP
+        """
+        return DatasetIndexer(self)
+
+    @property
     def coverage(self) -> Coverage:
         """Coverage summary of the dataset.
 
@@ -111,6 +222,39 @@ class Dataset(pyd.BaseModel, Generic[T]):
             >>> ds.coverage.plot()   # the timeline  # doctest: +SKIP
         """
         return Coverage(self)
+
+    @property
+    def info(self) -> pd.DataFrame:
+        """Per-timeseries metadata summary, rendered as a table.
+
+        One row per timeseries — ``location``, ``variable``, ``sensor``, the number of
+        ``records``, and the ``start`` / ``end`` of its time span. A quick look at what
+        a Dataset holds before processing it (the default repr only shows the timeseries
+        count). See :attr:`coverage` for a plottable version and :func:`gensor.diff` to
+        line this up across datasets.
+
+        Examples:
+            >>> ds.info  # doctest: +SKIP
+        """
+        columns = ["location", "variable", "sensor", "records", "start", "end"]
+        table = pd.DataFrame(
+            [
+                {
+                    "location": ts.location,
+                    "variable": ts.variable,
+                    "sensor": getattr(ts, "sensor", None),
+                    "records": len(ts.ts),
+                    "start": ts.ts.index.min(),
+                    "end": ts.ts.index.max(),
+                }
+                for ts in self.timeseries
+                if ts is not None and len(ts.ts) > 0
+            ],
+            columns=columns,
+        )
+        if not table.empty:
+            table = table.sort_values(["location", "variable", "sensor"]).reset_index(drop=True)
+        return table
 
     def diff(
         self,
@@ -192,10 +336,10 @@ class Dataset(pyd.BaseModel, Generic[T]):
 
     def filter(
         self,
+        *predicates: Where,
         location: str | list | None = None,
         variable: str | list | None = None,
         unit: str | list | None = None,
-        exclude: dict[str, str | list] | None = None,
         **kwargs: str | list,
     ) -> T | Dataset:
         """Return a Timeseries or a new Dataset filtered by station, sensor,
@@ -205,56 +349,34 @@ class Dataset(pyd.BaseModel, Generic[T]):
         a single value or a list of values, matching a timeseries when its attribute
         equals (or is in) the given value(s).
 
-        To filter by the *opposite* - dropping timeseries rather than selecting them -
-        pass ``exclude``, a dict of ``{attribute: value | list}``. A timeseries is
-        removed when it matches **all** conditions in ``exclude`` (e.g.
-        ``exclude={"location": "PB16D"}`` drops that location, while
-        ``exclude={"location": "PB03B", "sensor": "AV319"}`` drops only that one
-        sensor at that location). ``exclude`` is applied after the include filters.
+        Prefix a value with ``~`` to *negate* it - drop timeseries with that value
+        rather than keep them (e.g. ``location="~PB16D"`` keeps everything except
+        PB16D; ``sensor="~AV319"`` drops just that sensor). Positive and negated
+        values may be mixed within one attribute and across attributes; for a given
+        attribute a timeseries is kept when its value is in the positives (if any are
+        given) **and** not in the negatives, and attributes are AND-ed together.
+
+        For conditions the per-attribute keywords can't express - notably a *combined*
+        match across attributes - pass one or more :class:`Where` predicates
+        positionally. ``filter(~Where(location="PB03B", sensor="AV319"))`` drops only that
+        sensor at that location (the whole combination negated as a unit), while
+        ``filter(Where(location="PB16A") | Where(location="PB16B"))`` keeps either.
+        Predicates are AND-ed with the keyword filters.
 
         Parameters:
-            location (str | list, optional): The location name(s).
-            variable (str | list, optional): The variable(s) being measured.
-            unit (str | list, optional): Unit(s) of the measurement.
-            exclude (dict, optional): ``{attribute: value | list}`` conditions whose
-                (combined) match removes a timeseries from the result.
+            *predicates (Where): Predicate objects; all must match for a timeseries to
+                be kept (combine with ``& | ~``).
+            location (str | list, optional): The location name(s); ``~`` negates.
+            variable (str | list, optional): The variable(s) being measured; ``~`` negates.
+            unit (str | list, optional): Unit(s) of the measurement; ``~`` negates.
             **kwargs (str | list): Attributes of subclassed timeseries used for
-                filtering (e.g., sensor, method).
+                filtering (e.g., sensor, method); ``~`` negates.
 
         Returns:
             Timeseries | Dataset: A single Timeseries if exactly one match is found,
                                    or a new Dataset if multiple matches are found.
         """
-
-        def as_list(value: str | list | None) -> list | None:
-            return [value] if isinstance(value, str) else value
-
-        def matches(ts: T, attr: str, value: list) -> bool:
-            """Check the Timeseries has the attribute and its value is in ``value``."""
-            if not hasattr(ts, attr):
-                message = f"'{ts.__class__.__name__}' object has no attribute '{attr}'"
-                raise AttributeError(message)
-            return getattr(ts, attr) in value
-
-        location, variable, unit = as_list(location), as_list(variable), as_list(unit)
-        kwargs = {attr: as_list(value) for attr, value in kwargs.items()}
-        exclude = {attr: as_list(value) for attr, value in (exclude or {}).items()}
-
-        def keep(ts: T | None) -> bool:
-            if ts is None:
-                return False
-            if location is not None and ts.location not in location:
-                return False
-            if variable is not None and ts.variable not in variable:
-                return False
-            if unit is not None and ts.unit not in unit:
-                return False
-            if not all(matches(ts, attr, value) for attr, value in kwargs.items()):
-                return False
-            if exclude and all(matches(ts, attr, value) for attr, value in exclude.items()):
-                return False
-            return True
-
+        keep = self._matcher(predicates, location, variable, unit, kwargs)
         matching_timeseries = [ts for ts in self.timeseries if keep(ts)]
 
         if not matching_timeseries:
@@ -264,6 +386,76 @@ class Dataset(pyd.BaseModel, Generic[T]):
             return matching_timeseries[0].model_copy(deep=True)
 
         return self.model_copy(update={"timeseries": matching_timeseries})
+
+    def pop(
+        self,
+        *predicates: Where,
+        location: str | list | None = None,
+        variable: str | list | None = None,
+        unit: str | list | None = None,
+        **kwargs: str | list,
+    ) -> T | Dataset:
+        """Remove and return the matching timeseries, mutating the Dataset in place.
+
+        Selection works exactly like :meth:`filter` (same ``location`` / ``variable`` /
+        ``unit`` / keyword filters, ``~`` negation, and :class:`Where` predicates), but
+        the matched timeseries are **removed** from this Dataset and returned **by
+        reference** (not copied) - so you can alter them and ``add()`` them back in their
+        new form::
+
+            ts = ds.pop(location="PB03B", sensor="AV319")   # taken out of ds
+            ts.ts = ts.ts - 300                             # edit the live series
+            ds.add(ts)                                       # put it back, changed
+
+        Parameters:
+            *predicates (Where): Predicate objects; all must match (combine with ``& | ~``).
+            location (str | list, optional): The location name(s); ``~`` negates.
+            variable (str | list, optional): The variable(s) being measured; ``~`` negates.
+            unit (str | list, optional): Unit(s) of the measurement; ``~`` negates.
+            **kwargs (str | list): Other timeseries attributes to match (e.g., sensor).
+
+        Returns:
+            Timeseries | Dataset: A single Timeseries if exactly one match is removed, a
+                new Dataset of them if several match, or an empty Dataset if none match
+                (in which case nothing is removed).
+        """
+        keep = self._matcher(predicates, location, variable, unit, kwargs)
+
+        popped: list[T | None] = []
+        remaining: list[T | None] = []
+        for ts in self.timeseries:
+            (popped if keep(ts) else remaining).append(ts)
+
+        self.timeseries = remaining
+
+        if not popped:
+            return Dataset()
+        if len(popped) == 1:
+            return popped[0]
+        return Dataset(timeseries=popped)
+
+    def _matcher(
+        self,
+        predicates: tuple,
+        location: str | list | None,
+        variable: str | list | None,
+        unit: str | list | None,
+        kwargs: dict,
+    ) -> Any:
+        """Build the ``keep(ts)`` predicate shared by :meth:`filter` and :meth:`pop`.
+
+        A timeseries is kept when it matches every keyword filter (``~`` negation
+        included) and every positional :class:`Where` predicate. ``None`` entries never
+        match.
+        """
+        keywords = {"location": location, "variable": variable, "unit": unit, **kwargs}
+        tests = [Where(**{attr: value}) for attr, value in keywords.items() if value is not None]
+        tests.extend(predicates)
+
+        def keep(ts: T | None) -> bool:
+            return ts is not None and all(test(ts) for test in tests)
+
+        return keep
 
     def to_sql(self, db: DatabaseConnection) -> None:
         """Save the entire timeseries to a SQLite database.
@@ -285,50 +477,111 @@ class Dataset(pyd.BaseModel, Generic[T]):
 
     def plot(
         self,
+        facet: str = "variable",
+        variable: str | list | None = None,
+        ncols: int = 5,
+        sharex: bool = False,
         include_outliers: bool = False,
         plot_kwargs: dict[str, Any] | None = None,
         legend_kwargs: dict[str, Any] | None = None,
-    ) -> tuple[Figure, Axes]:
-        """Plots the timeseries data, grouping by variable type.
+    ) -> tuple[Figure, list] | dict[str, tuple[Figure, list]]:
+        """Plot the dataset's timeseries, in one of two layouts.
+
+        - ``facet="variable"`` (default): one subplot per variable (pressure,
+          temperature, ...), every location's series overlaid on that axis. Returns
+          ``(fig, axes)`` where ``axes`` is a list (one per variable).
+        - ``facet="location"``: a **separate figure per variable**, each a grid with one
+          panel per location (``ncols`` wide). Every location gets a panel - left empty
+          if it has no (or empty) series for that variable - and unused trailing cells are
+          hidden. Multiple sensors at a location are overlaid in the same panel, and a
+          legend (labelled by **sensor serial**) is shown only then; single-series panels
+          get no legend. Panels are titled by location and carry no x-label (the dates are
+          on the shared/rotated ticks). Returns ``{variable: (fig, axes)}``.
 
         Parameters:
+            facet (str): ``"variable"`` or ``"location"``.
+            variable (str | list, optional): restrict to these variable(s); default is
+                every unique variable in the dataset.
+            ncols (int): panels per row for the ``facet="location"`` grid.
+            sharex (bool): for ``facet="location"``, share the x-axis across all panels so
+                every row and column is aligned to the same (full) time span - the
+                longest-running series sets the extent, and empty panels span it too.
             include_outliers (bool): Whether to include outliers in the plot.
-            plot_kwargs (dict[str, Any] | None): kwargs passed to matplotlib.axes.Axes.plot() method to customize the plot.
-            legend_kwargs (dict[str, Any] | None): kwargs passed to matplotlib.axes.Axes.legend() to customize the legend.
+            plot_kwargs (dict[str, Any] | None): kwargs passed to matplotlib.axes.Axes.plot().
+            legend_kwargs (dict[str, Any] | None): kwargs passed to matplotlib.axes.Axes.legend().
 
         Returns:
-            (fig, ax): Matplotlib figure and axes to allow further customization.
+            ``(fig, axes)`` for ``facet="variable"``; a ``{variable: (fig, axes)}`` dict
+            for ``facet="location"``.
         """
-
-        grouped_ts = defaultdict(list)
-
-        for ts in self.timeseries:
-            if ts:
-                grouped_ts[ts.variable].append(ts)
-
-        num_variables = len(grouped_ts)
-
-        fig, axes = plt.subplots(
-            num_variables, 1, figsize=(10, 5 * num_variables), sharex=True
+        variables = (
+            [variable]
+            if isinstance(variable, str)
+            else list(variable)
+            if variable is not None
+            else sorted({ts.variable for ts in self.timeseries if ts is not None})
         )
 
-        if num_variables == 1:
-            axes = [axes]
+        if facet == "variable":
+            fig, axes = plt.subplots(
+                len(variables), 1, figsize=(10, 5 * len(variables)), sharex=True, squeeze=False
+            )
+            axes = list(axes.ravel())
+            for ax, var in zip(axes, variables, strict=False):
+                for ts in self.timeseries:
+                    if ts is not None and ts.variable == var and len(ts.ts) > 0:
+                        ts.plot(
+                            include_outliers=include_outliers,
+                            ax=ax,
+                            plot_kwargs=plot_kwargs,
+                            legend_kwargs=legend_kwargs,
+                        )
+                ax.set_title(f"Timeseries for {var.capitalize()}")
+                ax.set_xlabel("Time")
+            fig.tight_layout()
+            return fig, axes
 
-        for ax, (variable, ts_list) in zip(axes, grouped_ts.items(), strict=False):
-            for ts in ts_list:
-                ts.plot(
-                    include_outliers=include_outliers,
-                    ax=ax,
-                    plot_kwargs=plot_kwargs,
-                    legend_kwargs=legend_kwargs,
+        if facet == "location":
+            locations = self.get_locations()
+            nrows = (len(locations) + ncols - 1) // ncols if locations else 1
+            pkw = {"lw": 0.7, **(plot_kwargs or {})}
+            lkw = {"fontsize": 7, **(legend_kwargs or {})}
+            results: dict[str, tuple[Figure, list]] = {}
+            for var in variables:
+                fig, axs = plt.subplots(
+                    nrows, ncols, figsize=(4 * ncols, 2.3 * nrows), squeeze=False, sharex=sharex
                 )
+                axes = list(axs.ravel())
+                for ax, loc in zip(axes, locations, strict=False):
+                    series = [
+                        ts
+                        for ts in self.timeseries
+                        if ts is not None
+                        and ts.location == loc
+                        and ts.variable == var
+                        and len(ts.ts) > 0
+                    ]
+                    for ts in series:
+                        ax.plot(ts.ts.index, ts.ts.to_numpy(), label=ts.sensor, **pkw)
+                        if include_outliers and ts.outliers is not None and len(ts.outliers) > 0:
+                            ax.scatter(ts.outliers.index, ts.outliers, color="red", s=5)
+                    ax.set_title(loc, fontsize=8)  # every location keeps a panel, even if empty
+                    ax.tick_params(labelsize=6)
+                    for label in ax.get_xticklabels():
+                        label.set_rotation(45)
+                        label.set_ha("right")
+                    # only worth a legend when sensors share a panel; label them by serial
+                    if len(series) > 1:
+                        ax.legend(**lkw)
+                for ax in axes[len(locations):]:
+                    ax.set_visible(False)  # hide unused trailing cells
+                fig.suptitle(f"{var.capitalize()} by location", fontsize=13)
+                fig.tight_layout(rect=(0, 0, 1, 0.98))  # leave room for the suptitle
+                results[var] = (fig, axes)
+            return results
 
-            ax.set_title(f"Timeseries for {variable.capitalize()}")
-            ax.set_xlabel("Time")
-
-        fig.tight_layout()
-        return fig, axes
+        message = f"facet must be 'variable' or 'location', got {facet!r}."
+        raise ValueError(message)
 
 
 def _coverage_segments(index: pd.DatetimeIndex, threshold: pd.Timedelta) -> list[tuple]:
@@ -357,31 +610,17 @@ class Coverage:
     its record count and time span) and renders as that table in a notebook. Call
     :meth:`plot` for a coverage timeline (one row per location; bars span contiguous
     data, breaks mark gaps longer than ``max_gap``).
+
+    The table is :attr:`Dataset.info` with a derived ``duration`` column appended, so
+    the per-series summary has a single source.
     """
 
-    columns = ["location", "variable", "sensor", "unit", "records", "start", "end", "duration"]
+    columns = ["location", "variable", "sensor", "records", "start", "end", "duration"]
 
     def __init__(self, dataset: Dataset) -> None:
         self._dataset = dataset
-        table = pd.DataFrame(
-            [
-                {
-                    "location": ts.location,
-                    "variable": ts.variable,
-                    "sensor": getattr(ts, "sensor", None),
-                    "unit": ts.unit,
-                    "records": len(ts.ts),
-                    "start": ts.ts.index.min(),
-                    "end": ts.ts.index.max(),
-                    "duration": ts.ts.index.max() - ts.ts.index.min(),
-                }
-                for ts in dataset
-                if ts is not None and len(ts.ts) > 0
-            ],
-            columns=self.columns,
-        )
-        if not table.empty:
-            table = table.sort_values(["location", "variable"]).reset_index(drop=True)
+        table = dataset.info
+        table["duration"] = table["end"] - table["start"]
         self.table = table
 
     def __repr__(self) -> str:
@@ -461,34 +700,49 @@ class CoverageDiff:
         self.key = tuple(key)
         self.labels = list(datasets)
 
-        # per label: key-tuple -> {sensor, records, start, end, index}
+        # per label: key-tuple -> {sensor, records, start, end}, collapsed from the
+        # dataset's `.info` table; plus the union DatetimeIndex per key, kept only for
+        # the timeline plot.
         self._coverage: dict[str, dict[tuple, dict]] = {}
+        self._index: dict[str, dict[tuple, pd.DatetimeIndex]] = {}
         for label, dataset in datasets.items():
-            grouped: dict[tuple, dict] = {}
+            self._coverage[label] = self._summarise(dataset.info)
+            index_by_key: dict[tuple, pd.DatetimeIndex] = {}
             for ts in dataset:
                 if ts is None or len(ts.ts) == 0:
                     continue
                 k = tuple(getattr(ts, attr) for attr in self.key)
-                entry = grouped.setdefault(k, {"sensors": set(), "index": None})
-                entry["index"] = (
-                    ts.ts.index
-                    if entry["index"] is None
-                    else entry["index"].union(ts.ts.index)
+                index_by_key[k] = (
+                    ts.ts.index if k not in index_by_key else index_by_key[k].union(ts.ts.index)
                 )
-                entry["sensors"].add(getattr(ts, "sensor", None))
-            self._coverage[label] = {
-                k: {
-                    "sensor": "+".join(sorted(s for s in v["sensors"] if s)) or None,
-                    "records": len(v["index"]),
-                    "start": v["index"].min(),
-                    "end": v["index"].max(),
-                    "index": v["index"].sort_values(),
-                }
-                for k, v in grouped.items()
-            }
+            self._index[label] = {k: idx.sort_values() for k, idx in index_by_key.items()}
 
         self.keys = sorted({k for cov in self._coverage.values() for k in cov})
         self.table = self._build_table()
+
+    def _summarise(self, info: pd.DataFrame) -> dict[tuple, dict]:
+        """Collapse a :attr:`Dataset.info` table into one summary row per comparison
+        ``key`` (the key columns must be present in ``info``). Timeseries sharing a key
+        are merged: sensors joined, records summed, span widened to the outer bounds."""
+        summary: dict[tuple, dict] = {}
+        for row in info.itertuples(index=False):
+            k = tuple(getattr(row, attr) for attr in self.key)
+            entry = summary.setdefault(
+                k, {"sensors": set(), "records": 0, "start": row.start, "end": row.end}
+            )
+            entry["sensors"].add(row.sensor)
+            entry["records"] += int(row.records)
+            entry["start"] = min(entry["start"], row.start)
+            entry["end"] = max(entry["end"], row.end)
+        return {
+            k: {
+                "sensor": "+".join(sorted(s for s in v["sensors"] if s)) or None,
+                "records": v["records"],
+                "start": v["start"],
+                "end": v["end"],
+            }
+            for k, v in summary.items()
+        }
 
     def _status(self, k: tuple) -> str:
         present = [lab for lab in self.labels if k in self._coverage[lab]]
@@ -566,12 +820,12 @@ class CoverageDiff:
         sub_h = 0.8 / n
         for row, k in enumerate(self.keys):
             for j, label in enumerate(self.labels):
-                info = self._coverage[label].get(k)
-                if info is None:
+                index = self._index[label].get(k)
+                if index is None or len(index) == 0:
                     continue
                 y = row - 0.4 + j * sub_h
                 ax.broken_barh(
-                    _coverage_segments(info["index"], threshold),
+                    _coverage_segments(index, threshold),
                     (y, sub_h * 0.9),
                     facecolors=colors[label],
                 )

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -112,6 +112,25 @@ class Dataset(pyd.BaseModel, Generic[T]):
         """
         return Coverage(self)
 
+    def diff(
+        self,
+        *others: Dataset,
+        labels: list[str] | None = None,
+        key: tuple[str, ...] = ("location", "variable"),
+    ) -> CoverageDiff:
+        """Compare this dataset's coverage with one or more others.
+
+        Convenience wrapper over :func:`gensor.diff`. ``labels`` names this dataset
+        and the others (default ``ds0``, ``ds1`` ...).
+
+        Examples:
+            >>> raw.diff(trimmed, labels=["raw", "trimmed"]).plot()  # doctest: +SKIP
+        """
+        datasets = [self, *others]
+        if labels is None:
+            labels = [f"ds{i}" for i in range(len(datasets))]
+        return diff(dict(zip(labels, datasets, strict=True)), key=key)
+
     def one(self, **filters: Any) -> T:
         """Return exactly one matching Timeseries.
 
@@ -312,6 +331,25 @@ class Dataset(pyd.BaseModel, Generic[T]):
         return fig, axes
 
 
+def _coverage_segments(index: pd.DatetimeIndex, threshold: pd.Timedelta) -> list[tuple]:
+    """Split a DatetimeIndex into ``(start, width)`` segments (in Matplotlib date
+    units) of contiguous data, breaking wherever the gap between consecutive samples
+    exceeds ``threshold``. Used to draw coverage bars with within-record gaps shown.
+    """
+    from matplotlib.dates import date2num
+
+    index = index.sort_values()
+    bars: list[tuple] = []
+    seg_start = previous = index[0]
+    for stamp in index[1:]:
+        if stamp - previous > threshold:
+            bars.append((date2num(seg_start), date2num(previous) - date2num(seg_start)))
+            seg_start = stamp
+        previous = stamp
+    bars.append((date2num(seg_start), date2num(previous) - date2num(seg_start)))
+    return bars
+
+
 class Coverage:
     """Coverage summary of a :class:`Dataset`, returned by ``Dataset.coverage``.
 
@@ -371,8 +409,6 @@ class Coverage:
         Returns:
             (fig, ax): Matplotlib figure and axes.
         """
-        from matplotlib.dates import date2num
-
         threshold = pd.Timedelta(max_gap)
         locations = self._dataset.get_locations()
 
@@ -389,19 +425,7 @@ class Coverage:
                 index = ts.ts.index if index is None else index.union(ts.ts.index)
             if index is None or len(index) == 0:
                 continue
-            index = index.sort_values()
-
-            # split into contiguous segments wherever a gap exceeds the threshold
-            bars = []
-            seg_start = previous = index[0]
-            for stamp in index[1:]:
-                if stamp - previous > threshold:
-                    bars.append((date2num(seg_start), date2num(previous) - date2num(seg_start)))
-                    seg_start = stamp
-                previous = stamp
-            bars.append((date2num(seg_start), date2num(previous) - date2num(seg_start)))
-
-            ax.broken_barh(bars, (row - 0.4, 0.8), facecolors=color)
+            ax.broken_barh(_coverage_segments(index, threshold), (row - 0.4, 0.8), facecolors=color)
 
         ax.set_yticks(range(len(locations)))
         ax.set_yticklabels(locations, fontsize=8)
@@ -411,3 +435,181 @@ class Coverage:
         ax.grid(axis="x", alpha=0.3)
         fig.tight_layout()
         return fig, ax
+
+
+class CoverageDiff:
+    """Coverage comparison of two or more datasets, returned by :func:`gensor.diff`
+    (or ``Dataset.diff``).
+
+    Series are aligned across datasets by ``key`` (default ``("location",
+    "variable")``); multiple sensors sharing a key are unioned and the sensor(s)
+    reported. Renders as a wide ``table`` (per-dataset record count / start / end,
+    plus ``present`` and ``status`` summary columns) and exposes :meth:`plot` for an
+    N-way coverage timeline grouped by timeseries.
+    """
+
+    def __init__(
+        self,
+        datasets: dict[str, Dataset],
+        key: tuple[str, ...] = ("location", "variable"),
+    ) -> None:
+        if len(datasets) < 2:
+            message = "CoverageDiff needs at least two datasets to compare."
+            raise ValueError(message)
+
+        self._datasets = dict(datasets)
+        self.key = tuple(key)
+        self.labels = list(datasets)
+
+        # per label: key-tuple -> {sensor, records, start, end, index}
+        self._coverage: dict[str, dict[tuple, dict]] = {}
+        for label, dataset in datasets.items():
+            grouped: dict[tuple, dict] = {}
+            for ts in dataset:
+                if ts is None or len(ts.ts) == 0:
+                    continue
+                k = tuple(getattr(ts, attr) for attr in self.key)
+                entry = grouped.setdefault(k, {"sensors": set(), "index": None})
+                entry["index"] = (
+                    ts.ts.index
+                    if entry["index"] is None
+                    else entry["index"].union(ts.ts.index)
+                )
+                entry["sensors"].add(getattr(ts, "sensor", None))
+            self._coverage[label] = {
+                k: {
+                    "sensor": "+".join(sorted(s for s in v["sensors"] if s)) or None,
+                    "records": len(v["index"]),
+                    "start": v["index"].min(),
+                    "end": v["index"].max(),
+                    "index": v["index"].sort_values(),
+                }
+                for k, v in grouped.items()
+            }
+
+        self.keys = sorted({k for cov in self._coverage.values() for k in cov})
+        self.table = self._build_table()
+
+    def _status(self, k: tuple) -> str:
+        present = [lab for lab in self.labels if k in self._coverage[lab]]
+        if len(present) < len(self.labels):
+            return "only " + ", ".join(present)
+        records = {self._coverage[lab][k]["records"] for lab in self.labels}
+        spans = {
+            (self._coverage[lab][k]["start"], self._coverage[lab][k]["end"])
+            for lab in self.labels
+        }
+        if len(records) == 1 and len(spans) == 1:
+            return "identical"
+        return "span differs" if len(spans) > 1 else "records differ"
+
+    def _build_table(self) -> pd.DataFrame:
+        defaults = {"sensor": None, "records": 0, "start": pd.NaT, "end": pd.NaT}
+        data: dict[tuple, list] = {}
+        for label in self.labels:
+            cov = self._coverage[label]
+            for metric in ("sensor", "records", "start", "end"):
+                data[(label, metric)] = [
+                    cov.get(k, defaults).get(metric, defaults[metric]) for k in self.keys
+                ]
+        data[("summary", "present")] = [
+            sum(k in self._coverage[lab] for lab in self.labels) for k in self.keys
+        ]
+        data[("summary", "status")] = [self._status(k) for k in self.keys]
+
+        table = pd.DataFrame(
+            data,
+            index=pd.MultiIndex.from_tuples(self.keys, names=self.key),
+        )
+        table.columns = pd.MultiIndex.from_tuples(table.columns)
+        return table
+
+    def __repr__(self) -> str:
+        return self.table.to_string()
+
+    def _repr_html_(self) -> str:
+        return self.table.to_html()
+
+    def plot(
+        self,
+        max_gap: str = "7D",
+        ax: Axes | None = None,
+        colors: dict[str, Any] | None = None,
+    ) -> tuple[Figure, Axes]:
+        """Plot an N-way coverage timeline grouped by timeseries.
+
+        One row per ``key`` (e.g. location + variable); within each row a coverage
+        sub-bar per dataset (colour-coded, with a legend). Series present in only one
+        dataset, or covering different spans, are immediately visible.
+
+        Parameters:
+            max_gap (str): pandas timedelta string; gaps longer than this split a bar.
+            ax (Axes | None): existing axes to draw on; a new figure is created if None.
+            colors (dict | None): optional ``{label: colour}`` mapping.
+
+        Returns:
+            (fig, ax): Matplotlib figure and axes.
+        """
+        from matplotlib.patches import Patch
+
+        threshold = pd.Timedelta(max_gap)
+        if colors is None:
+            cmap = plt.get_cmap("tab10")
+            colors = {lab: cmap(i % 10) for i, lab in enumerate(self.labels)}
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(13, 0.45 * len(self.keys) + 1.5))
+        else:
+            fig = ax.figure
+
+        n = len(self.labels)
+        sub_h = 0.8 / n
+        for row, k in enumerate(self.keys):
+            for j, label in enumerate(self.labels):
+                info = self._coverage[label].get(k)
+                if info is None:
+                    continue
+                y = row - 0.4 + j * sub_h
+                ax.broken_barh(
+                    _coverage_segments(info["index"], threshold),
+                    (y, sub_h * 0.9),
+                    facecolors=colors[label],
+                )
+
+        ax.set_yticks(range(len(self.keys)))
+        ax.set_yticklabels([" ".join(map(str, k)) for k in self.keys], fontsize=7)
+        ax.invert_yaxis()
+        ax.xaxis_date()
+        ax.set_title("Coverage diff")
+        ax.grid(axis="x", alpha=0.3)
+        ax.legend(
+            handles=[Patch(facecolor=colors[lab], label=lab) for lab in self.labels],
+            bbox_to_anchor=(1.01, 1),
+            loc="upper left",
+            frameon=True,
+        )
+        fig.tight_layout()
+        return fig, ax
+
+
+def diff(
+    datasets: dict[str, Dataset] | list[Dataset],
+    key: tuple[str, ...] = ("location", "variable"),
+) -> CoverageDiff:
+    """Compare the coverage of two or more datasets.
+
+    Parameters:
+        datasets: a mapping ``{label: Dataset}`` (preferred - labels name the columns
+            and legend) or a list of datasets (auto-labelled ``ds0``, ``ds1`` ...).
+        key: attributes used to align series across datasets (default
+            ``("location", "variable")``).
+
+    Returns:
+        CoverageDiff: renders as a comparison table; ``.plot()`` draws the timeline.
+    """
+    if isinstance(datasets, Dataset):
+        message = "Pass two or more datasets to diff(), e.g. diff({'a': ds1, 'b': ds2})."
+        raise TypeError(message)
+    if not isinstance(datasets, dict):
+        datasets = {f"ds{i}": d for i, d in enumerate(datasets)}
+    return CoverageDiff(datasets, key=key)

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -4,6 +4,7 @@ import logging
 from collections import defaultdict
 from typing import Any, Generic
 
+import pandas as pd
 import pydantic as pyd
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
@@ -97,6 +98,19 @@ class Dataset(pyd.BaseModel, Generic[T]):
             if ts is not None and ts.location not in locations:
                 locations.append(ts.location)
         return locations
+
+    @property
+    def coverage(self) -> Coverage:
+        """Coverage summary of the dataset.
+
+        Renders as a per-timeseries table (records and time span per location /
+        variable / sensor) and exposes :meth:`Coverage.plot` for a coverage timeline.
+
+        Examples:
+            >>> ds.coverage          # the table  # doctest: +SKIP
+            >>> ds.coverage.plot()   # the timeline  # doctest: +SKIP
+        """
+        return Coverage(self)
 
     def one(self, **filters: Any) -> T:
         """Return exactly one matching Timeseries.
@@ -296,3 +310,104 @@ class Dataset(pyd.BaseModel, Generic[T]):
 
         fig.tight_layout()
         return fig, axes
+
+
+class Coverage:
+    """Coverage summary of a :class:`Dataset`, returned by ``Dataset.coverage``.
+
+    Holds a per-timeseries ``table`` (one row per location / variable / sensor with
+    its record count and time span) and renders as that table in a notebook. Call
+    :meth:`plot` for a coverage timeline (one row per location; bars span contiguous
+    data, breaks mark gaps longer than ``max_gap``).
+    """
+
+    columns = ["location", "variable", "sensor", "unit", "records", "start", "end", "duration"]
+
+    def __init__(self, dataset: Dataset) -> None:
+        self._dataset = dataset
+        table = pd.DataFrame(
+            [
+                {
+                    "location": ts.location,
+                    "variable": ts.variable,
+                    "sensor": getattr(ts, "sensor", None),
+                    "unit": ts.unit,
+                    "records": len(ts.ts),
+                    "start": ts.ts.index.min(),
+                    "end": ts.ts.index.max(),
+                    "duration": ts.ts.index.max() - ts.ts.index.min(),
+                }
+                for ts in dataset
+                if ts is not None and len(ts.ts) > 0
+            ],
+            columns=self.columns,
+        )
+        if not table.empty:
+            table = table.sort_values(["location", "variable"]).reset_index(drop=True)
+        self.table = table
+
+    def __repr__(self) -> str:
+        return self.table.to_string(index=False)
+
+    def _repr_html_(self) -> str:
+        return self.table.to_html(index=False)
+
+    def plot(
+        self,
+        max_gap: str = "7D",
+        ax: Axes | None = None,
+        color: str = "#1f4e79",
+    ) -> tuple[Figure, Axes]:
+        """Plot a coverage timeline: one row per location, with bars spanning
+        contiguous data and breaks wherever the gap between consecutive samples
+        exceeds ``max_gap``.
+
+        Parameters:
+            max_gap (str): pandas timedelta string; a gap longer than this splits a
+                bar so within-record holes (e.g. a missing season) stay visible.
+            ax (Axes | None): existing axes to draw on; a new figure is created if None.
+            color (str): bar colour.
+
+        Returns:
+            (fig, ax): Matplotlib figure and axes.
+        """
+        from matplotlib.dates import date2num
+
+        threshold = pd.Timedelta(max_gap)
+        locations = self._dataset.get_locations()
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(12, 0.35 * len(locations) + 1))
+        else:
+            fig = ax.figure
+
+        for row, location in enumerate(locations):
+            index = None
+            for ts in self._dataset:
+                if ts is None or ts.location != location or len(ts.ts) == 0:
+                    continue
+                index = ts.ts.index if index is None else index.union(ts.ts.index)
+            if index is None or len(index) == 0:
+                continue
+            index = index.sort_values()
+
+            # split into contiguous segments wherever a gap exceeds the threshold
+            bars = []
+            seg_start = previous = index[0]
+            for stamp in index[1:]:
+                if stamp - previous > threshold:
+                    bars.append((date2num(seg_start), date2num(previous) - date2num(seg_start)))
+                    seg_start = stamp
+                previous = stamp
+            bars.append((date2num(seg_start), date2num(previous) - date2num(seg_start)))
+
+            ax.broken_barh(bars, (row - 0.4, 0.8), facecolors=color)
+
+        ax.set_yticks(range(len(locations)))
+        ax.set_yticklabels(locations, fontsize=8)
+        ax.invert_yaxis()
+        ax.xaxis_date()
+        ax.set_title("Data coverage")
+        ax.grid(axis="x", alpha=0.3)
+        fig.tight_layout()
+        return fig, ax

--- a/gensor/core/dataset.py
+++ b/gensor/core/dataset.py
@@ -36,29 +36,42 @@ class Dataset(pyd.BaseModel, Generic[T]):
     def __repr__(self) -> str:
         return f"Dataset({len(self)})"
 
-    def __getitem__(self, key: int | str | list) -> T | None | Dataset:
-        """Retrieve Timeseries by integer index or by location name.
+    def __getitem__(self, key: int | str | list | tuple) -> T | None | Dataset:
+        """Retrieve Timeseries by integer index, location name, or (location,
+        variable[, unit]) tuple.
 
         - ``dataset[0]`` returns the Timeseries at that position (a reference).
         - ``dataset["PB01A"]`` returns the Timeseries at that location, or a
           Dataset if the location has several timeseries (e.g. pressure and
           temperature). A list of names (``dataset[["PB01A", "PB02A"]]``) always
           returns a Dataset.
+        - ``dataset["PB01A", "pressure"]`` (or ``["PB01A", "pressure", "cmh2o"]``)
+          narrows by variable/unit, returning a single Timeseries when one matches.
+          For full control use :meth:`filter` / :meth:`one`.
 
         !!! warning
-            Integer indexing returns a reference to the timeseries. Location
-            indexing returns copies (it delegates to ``.filter()``).
+            Integer indexing returns a reference to the timeseries. Location /
+            tuple indexing returns copies (it delegates to ``.filter()``).
 
         Parameters:
-            key (int | str | list): Position, location name, or list of names.
+            key (int | str | list | tuple): Position, location name, list of
+                names, or a (location, variable[, unit]) tuple.
 
         Returns:
             Timeseries | Dataset: The matching timeseries or a dataset of them.
 
         Raises:
             IndexOutOfRangeError: If an integer index is out of range.
-            KeyError: If no timeseries matches the given location(s).
+            KeyError: If no timeseries matches the given location(s)/filters.
         """
+        if isinstance(key, tuple):
+            location, variable, unit = (*key, None, None)[:3]
+            result = self.filter(location=location, variable=variable, unit=unit)
+            if isinstance(result, Dataset) and len(result) == 0:
+                message = f"No timeseries found for {key!r}."
+                raise KeyError(message)
+            return result
+
         if isinstance(key, (str, list)):
             result = self.filter(location=key)
             if isinstance(result, Dataset) and len(result) == 0:

--- a/gensor/parse/utils.py
+++ b/gensor/parse/utils.py
@@ -78,6 +78,37 @@ def get_metadata(text: str, patterns: dict) -> dict:
     return metadata
 
 
+def get_header_fields(text: str) -> dict:
+    """Parse the ``key = value`` lines of a Diver-Office header into a dict.
+
+    Diver-Office files carry labelled fields in the header (e.g. ``Location`` and
+    ``Serial number``); reading those directly is far more reliable than matching a
+    regex against the whole file, which can pick up stray matches from the embedded
+    ``FILENAME`` path. Parsing stops at the data block, section markers
+    (``[Logger settings]`` ...) and lines without a ``key = value`` shape are
+    skipped, and the first occurrence of each key wins.
+
+    Parameters:
+        text (str): string obtained from the CSV file.
+
+    Returns:
+        dict: header field name -> value (both stripped).
+    """
+    fields: dict[str, str] = {}
+
+    for line in text.splitlines():
+        if "Date/time" in line:  # start of the data block
+            break
+        if not line.strip() or line.lstrip().startswith("["):
+            continue
+        key, sep, value = line.partition("=")
+        key = key.strip()
+        if sep and key and key not in fields:
+            fields[key] = value.strip()
+
+    return fields
+
+
 def detect_encoding(path: Path, num_bytes: int = 1024) -> str:
     """Detect the encoding of a file using chardet.
 

--- a/gensor/parse/utils.py
+++ b/gensor/parse/utils.py
@@ -7,6 +7,17 @@ from dateutil import tz
 from pandas import DataFrame, read_csv, to_datetime
 
 
+def _sniff_delimiter(header_line: str) -> str:
+    """Guess the column delimiter from the data header line.
+
+    Diver-Office exports are usually comma-separated, but some (e.g. certain
+    barometric exports) use a semicolon or tab. Falls back to ',' .
+    """
+    counts = {sep: header_line.count(sep) for sep in (",", ";", "\t")}
+    best = max(counts, key=lambda sep: counts[sep])
+    return best if counts[best] else ","
+
+
 def get_data(
     text: str, data_start: str, data_end: str, column_names: list
 ) -> DataFrame:
@@ -14,18 +25,35 @@ def get_data(
 
     Parameters:
         text (str): string obtained from the CSV file.
-        data_start (str): string at the first row of the data.
-        data_end (str): string at the last row of the data.
+        data_start (str): string marking the data header row.
+        data_end (str): string marking the end of the data block. When it is not
+            present (some exports omit the trailing marker), the data is read to
+            the end of the file.
         column_names (list): list of expected column names.
 
     Returns:
         pd.DataFrame
     """
 
-    data_io = StringIO(text[text.index(data_start) : text.index(data_end)])
+    start = text.find(data_start)
+    if start == -1:
+        message = f"Could not find the data header {data_start!r} in the file."
+        raise ValueError(message)
+
+    end = text.find(data_end, start)
+    if end == -1:  # exports without the trailing marker: read to end of file
+        end = len(text)
+
+    block = text[start:end]
+    sep = _sniff_delimiter(block.splitlines()[0])
 
     df = read_csv(
-        data_io, skiprows=1, header=None, names=column_names, index_col="timestamp"
+        StringIO(block),
+        skiprows=1,
+        header=None,
+        names=column_names,
+        index_col="timestamp",
+        sep=sep,
     )
 
     return df
@@ -46,9 +74,6 @@ def get_metadata(text: str, patterns: dict) -> dict:
     for k, v in patterns.items():
         match = re.search(v, text)
         metadata[k] = match.group() if match else None
-
-    if metadata["sensor"] is None or metadata["location"] is None:
-        return {}
 
     return metadata
 

--- a/gensor/parse/vanessen.py
+++ b/gensor/parse/vanessen.py
@@ -73,8 +73,12 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
         # Read the labelled header fields directly — far more reliable than matching a
         # regex against the whole file, which can grab a stray token from the embedded
         # FILENAME path (e.g. a folder name) instead of the real serial.
-        location = pick(patterns["location"], fields.get("Location"), kwargs.get("location"))
-        sensor = pick(patterns["sensor"], fields.get("Serial number"), kwargs.get("sensor"))
+        location = pick(
+            patterns["location"], fields.get("Location"), kwargs.get("location")
+        )
+        sensor = pick(
+            patterns["sensor"], fields.get("Serial number"), kwargs.get("sensor")
+        )
         tz_match = re.search(patterns["timezone"], text)
         timezone = tz_match.group() if tz_match else "UTC"
 
@@ -109,9 +113,7 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
                     )
                 )
             else:
-                message = (
-                    f"Unsupported variable: {col}. Please provide a valid variable type."
-                )
+                message = f"Unsupported variable: {col}. Please provide a valid variable type."
                 raise ValueError(message)
 
     return ts_list

--- a/gensor/parse/vanessen.py
+++ b/gensor/parse/vanessen.py
@@ -37,7 +37,7 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
     """
 
     patterns = {
-        "sensor": kwargs.get("serial_number_pattern", r"[A-Za-z]{2}\d{3,4}"),
+        "sensor": kwargs.get("serial_number_pattern", r"[A-Za-z]{1,2}\d{3,4}"),
         "location": kwargs.get(
             "location_pattern", r"[A-Za-z]{2}\d{2}[A-Za-z]{1}|Barodiver"
         ),
@@ -53,8 +53,18 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
 
         metadata = get_metadata(text, patterns)
 
-        if not metadata:
-            logger.info(f"Skipping file {path} due to missing metadata.")
+        # Explicit location/sensor kwargs take precedence over the regex-extracted
+        # values, so files whose serial/location format the patterns don't recognise
+        # can still be read by passing location=/sensor= directly.
+        location = kwargs.get("location") or metadata.get("location")
+        sensor = kwargs.get("sensor") or metadata.get("sensor")
+        timezone = metadata.get("timezone") or "UTC"
+
+        if location is None or sensor is None:
+            logger.info(
+                f"Skipping file {path} due to missing metadata "
+                "(pass location=/sensor= to override)."
+            )
             return []
 
         data_start = "Date/time"
@@ -62,7 +72,7 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
 
         df = get_data(text, data_start, data_end, column_names)
 
-        df = handle_timestamps(df, metadata.get("timezone", "UTC"))
+        df = handle_timestamps(df, timezone)
 
         ts_list = []
 
@@ -74,15 +84,15 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
                         ts=df[col],
                         # Validation will be done in Pydantic
                         variable=col,  # type: ignore[arg-type]
-                        location=metadata.get("location"),
-                        sensor=metadata.get("sensor"),
+                        location=location,
+                        sensor=sensor,
                         # Validation will be done in Pydantic
                         unit=unit,  # type: ignore[arg-type]
                     )
                 )
             else:
                 message = (
-                    "Unsupported variable: {col}. Please provide a valid variable type."
+                    f"Unsupported variable: {col}. Please provide a valid variable type."
                 )
                 raise ValueError(message)
 

--- a/gensor/parse/vanessen.py
+++ b/gensor/parse/vanessen.py
@@ -1,12 +1,13 @@
 """Logic parsing CSV files from van Essen Instruments Divers."""
 
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
 from ..config import VARIABLE_TYPES_AND_UNITS
 from ..core.timeseries import Timeseries
-from .utils import detect_encoding, get_data, get_metadata, handle_timestamps
+from .utils import detect_encoding, get_data, get_header_fields, handle_timestamps
 
 logger = logging.getLogger(__name__)
 
@@ -51,14 +52,31 @@ def parse_vanessen_csv(path: Path, **kwargs: Any) -> list[Timeseries]:
     with path.open(mode="r", encoding=encoding) as f:
         text = f.read()
 
-        metadata = get_metadata(text, patterns)
+        fields = get_header_fields(text)
 
-        # Explicit location/sensor kwargs take precedence over the regex-extracted
-        # values, so files whose serial/location format the patterns don't recognise
-        # can still be read by passing location=/sensor= directly.
-        location = kwargs.get("location") or metadata.get("location")
-        sensor = kwargs.get("sensor") or metadata.get("sensor")
-        timezone = metadata.get("timezone") or "UTC"
+        def pick(pattern: str, raw: str | None, override: str | None) -> str | None:
+            """Resolve a metadata value from a labelled header field.
+
+            An explicit ``location=``/``sensor=`` kwarg always wins. Otherwise the
+            pattern is matched against *that field's value only* (so e.g. the serial
+            ``AZ066`` is pulled out of ``..00-AZ066  219.`` and the location ``PB16A``
+            out of ``pb16a_moni_az066``), falling back to the verbatim field value
+            when the pattern does not match (e.g. ``FL1`` / ``barodiver`` locations).
+            """
+            if override:
+                return override
+            if not raw:
+                return None
+            match = re.search(pattern, raw)
+            return match.group() if match else raw
+
+        # Read the labelled header fields directly — far more reliable than matching a
+        # regex against the whole file, which can grab a stray token from the embedded
+        # FILENAME path (e.g. a folder name) instead of the real serial.
+        location = pick(patterns["location"], fields.get("Location"), kwargs.get("location"))
+        sensor = pick(patterns["sensor"], fields.get("Serial number"), kwargs.get("sensor"))
+        tz_match = re.search(patterns["timezone"], text)
+        timezone = tz_match.group() if tz_match else "UTC"
 
         if location is None or sensor is None:
             logger.info(

--- a/gensor/processing/compensation.py
+++ b/gensor/processing/compensation.py
@@ -9,15 +9,22 @@ the barometric pressure from the raw pressure measurements. For short time perio
 for instance a slug test is performed) the barometric pressure can be provided as a
 single float value.
 
-Subsequently the function filters out all records where the absolute water column is
-less than or equal to the cutoff value. This is because when the logger is out of the
-water when the measurement is taken, the absolute water column is close to zero,
-producing erroneous results and spikes in the plots. The cutoff value is set to 5 cm by
-default, but can be adjusted using the cutoff_wc kwarg.
+Subsequently the function filters out all records where the water column is less than or
+equal to the cutoff value, and - always, regardless of the cutoff - every record with a
+negative water column. The water column above a submerged sensor is physically
+non-negative, so the near-zero readings taken while the logger is out of the water (which
+produce erroneous results and spikes in the plots) and any negative values (out-of-water
+/ noise / barometric-alignment artefacts) are all erroneous. The comparison is signed,
+not on the absolute value, so large negative spikes are dropped rather than kept. The
+cutoff defaults to 25 mm (``threshold_wc=0.025``) and is always applied; lower it to keep
+shallower columns, or set it to 0 to drop only negatives.
 
 Functions:
 
-    compensate: Compensate raw sensor pressure measurement with barometric pressure.
+    water_column: Barometrically compensate raw pressure to the water column above the
+        sensor (the first step, without adding the sensor altitude).
+    compensate: Full compensation of raw sensor pressure to groundwater head, using
+        ``water_column`` and then adding the sensor altitude.
 """
 
 from typing import Literal
@@ -57,23 +64,34 @@ class Compensator(pyd.BaseModel):
             raise MissingInputError("sensor_alt")
         return v
 
-    def compensate(
+    def water_column(
         self,
         alignment_period: Literal["D", "ME", "SME", "MS", "YE", "YS", "h", "min", "s"],
         threshold_wc: float | None,
         fieldwork_dates: list | None,
     ) -> Timeseries | None:
-        """Perform compensation.
+        """Compute the barometrically compensated water column above the sensor.
+
+        Aligns the raw and barometric series to ``alignment_period``, subtracts the
+        barometric pressure, converts cmH2O to mH2O, masks fieldwork days, and drops the
+        out-of-water records (see ``threshold_wc``). This is the first step of
+        :meth:`compensate` and can be used on its own to obtain just the water column
+        height (it does not require ``sensor_alt``).
 
         Parameters:
             alignment_period Literal['D', 'ME', 'SME', 'MS', 'YE', 'YS', 'h', 'min', 's']: The alignment period for the timeseries.
                 Default is 'h'. See pandas offset aliases for definitinos.
-            threshold_wc (float): The threshold for the absolute water column.
+            threshold_wc (float | None): Lower cutoff (in m) for the water column.
+                Records at or below it are dropped, along with all negative water columns
+                (which are always dropped as physically impossible). ``None`` is treated
+                as ``0`` (drop only negatives).
             fieldwork_dates (Optional[list]): List of dates when fieldwork was done. All
                 measurement from a fieldwork day will be set to None.
 
         Returns:
-            Timeseries: A new Timeseries instance with the compensated data and updated unit and variable. Optionally removed outliers are included.
+            Timeseries: A new Timeseries of the water column height in metres (variable
+                'water_column', unit 'm'); dropped out-of-water records are kept in
+                ``.outliers``. ``None`` if the raw and barometric series are the same.
         """
 
         resample_params = {"freq": alignment_period, "agg_func": pd.Series.mean}
@@ -105,36 +123,107 @@ class Compensator(pyd.BaseModel):
                 watercolumn_ts.index.normalize().isin(fieldwork_timestamps)
             ] = None
 
-        if threshold_wc:
-            watercolumn_ts_filtered = watercolumn_ts[
-                watercolumn_ts.abs() > threshold_wc
-            ]
+        # The water column above a submerged sensor is physically non-negative, so any
+        # negative value (logger out of the water / noise / barometric misalignment) is
+        # always discarded - regardless of the cutoff. On top of that, the near-zero
+        # out-of-water band at or below ``threshold_wc`` (25 mm by default) is removed.
+        # This always runs; pass a smaller ``threshold_wc`` to keep shallower columns, or
+        # ``0`` to drop only negatives. NaN values (e.g. fieldwork-masked days) are left
+        # in place as gaps. A signed comparison is essential: ``.abs() > threshold`` would
+        # wrongly retain large-magnitude negatives.
+        cutoff = 0.0 if threshold_wc is None else float(threshold_wc)
+        invalid = (watercolumn_ts < 0) | (watercolumn_ts <= cutoff)
+        watercolumn_ts_filtered = watercolumn_ts[~invalid]
+        dropped_outliers = watercolumn_ts[invalid]
 
-            dropped_outliers = watercolumn_ts[watercolumn_ts.abs() <= threshold_wc]
-
+        if len(dropped_outliers):
             print(
-                f"{len(dropped_outliers)} records \
-                    dropped due to low water column."
-            )
-            gwl = watercolumn_ts_filtered.add(float(resampled_ts.sensor_alt or 0))
-
-            compensated = resampled_ts.model_copy(
-                update={
-                    "ts": gwl,
-                    "outliers": dropped_outliers,
-                    "unit": "m asl",
-                    "variable": "head",
-                },
-                deep=True,
-            )
-        else:
-            gwl = watercolumn_ts.add(float(resampled_ts.sensor_alt or 0))
-
-            compensated = resampled_ts.model_copy(
-                update={"ts": gwl, "unit": "m asl", "variable": "head"}, deep=True
+                f"{len(dropped_outliers)} records dropped "
+                f"(negative or <= {cutoff} m water column / out of water)."
             )
 
-        return compensated
+        return resampled_ts.model_copy(
+            update={
+                "ts": watercolumn_ts_filtered,
+                "outliers": dropped_outliers,
+                "unit": "m",
+                "variable": "water_column",
+            },
+            deep=True,
+        )
+
+    def compensate(
+        self,
+        alignment_period: Literal["D", "ME", "SME", "MS", "YE", "YS", "h", "min", "s"],
+        threshold_wc: float | None,
+        fieldwork_dates: list | None,
+    ) -> Timeseries | None:
+        """Perform full compensation to groundwater head (m asl).
+
+        Computes the water column with :meth:`water_column`, then adds the sensor
+        altitude (``sensor_alt``) to express it as head above the reference datum.
+
+        Parameters:
+            alignment_period Literal['D', 'ME', 'SME', 'MS', 'YE', 'YS', 'h', 'min', 's']: The alignment period for the timeseries.
+                Default is 'h'. See pandas offset aliases for definitinos.
+            threshold_wc (float | None): Lower cutoff (in m) for the water column; see
+                :meth:`water_column`.
+            fieldwork_dates (Optional[list]): List of dates when fieldwork was done. All
+                measurement from a fieldwork day will be set to None.
+
+        Returns:
+            Timeseries: A new Timeseries instance with the compensated data and updated unit and variable. Optionally removed outliers are included.
+        """
+        watercolumn = self.water_column(
+            alignment_period=alignment_period,
+            threshold_wc=threshold_wc,
+            fieldwork_dates=fieldwork_dates,
+        )
+        if watercolumn is None:
+            return None
+
+        gwl = watercolumn.ts.add(float(watercolumn.sensor_alt or 0))
+
+        return watercolumn.model_copy(
+            update={"ts": gwl, "unit": "m asl", "variable": "head"},
+            deep=True,
+        )
+
+
+def _apply(
+    step: Literal["compensate", "water_column"],
+    raw: Timeseries | Dataset,
+    barometric: Timeseries | float,
+    alignment_period: Literal["D", "ME", "SME", "MS", "YE", "YS", "h", "min", "s"],
+    threshold_wc: float | None,
+    fieldwork_dates: dict | None,
+    interpolate_method: str | None,
+) -> Timeseries | Dataset | None:
+    """Run a Compensator step (``compensate`` or ``water_column``) over a Timeseries or
+    every Timeseries in a Dataset, applying per-location fieldwork dates and optional
+    interpolation. Shared by :func:`compensate` and :func:`water_column`."""
+    if fieldwork_dates is None:
+        fieldwork_dates = {}
+
+    def _one(item: Timeseries, dates: list | None) -> Timeseries | None:
+        comp = Compensator(ts=item, barometric=barometric)
+        result = getattr(comp, step)(
+            alignment_period=alignment_period,
+            threshold_wc=threshold_wc,
+            fieldwork_dates=dates,
+        )
+        if result is not None and interpolate_method:
+            # .interpolate() on a Timeseries is wrapped to return a Timeseries from the
+            # original pandas.Series.interpolate().
+            return result.interpolate(method=interpolate_method)  # type: ignore[no-any-return]
+        return result
+
+    if isinstance(raw, Timeseries):
+        return _one(raw, fieldwork_dates.get(raw.location))
+
+    elif isinstance(raw, Dataset):
+        series = [_one(item, fieldwork_dates.get(item.location)) for item in raw]
+        return raw.model_copy(update={"timeseries": series}, deep=True)
 
 
 def compensate(
@@ -143,11 +232,13 @@ def compensate(
     alignment_period: Literal[
         "D", "ME", "SME", "MS", "YE", "YS", "h", "min", "s"
     ] = "h",
-    threshold_wc: float | None = None,
+    threshold_wc: float | None = 0.025,
     fieldwork_dates: dict | None = None,
     interpolate_method: str | None = None,
 ) -> Timeseries | Dataset | None:
-    """Constructor for the Comensator object.
+    """Compensate raw sensor pressure to groundwater head (m asl).
+
+    Computes the water column (see :func:`water_column`) and adds the sensor altitude.
 
     Parameters:
         raw (Timeseries | Dataset): Raw sensor timeseries
@@ -155,41 +246,61 @@ def compensate(
             float value. If a float value is provided, it is assumed to be in cmH2O.
         alignment_period (Literal['D', 'ME', 'SME', 'MS', 'YE', 'YS', 'h', 'min', 's']): The alignment period for the timeseries.
             Default is 'h'. See pandas offset aliases for definitinos.
-        threshold_wc (float): The threshold for the absolute water column. If it is
-            provided, the records below that threshold are dropped.
+        threshold_wc (float | None): Lower cutoff (in m) for the water column; records at
+            or below it are dropped. Defaults to 0.025 m (25 mm) and is always applied;
+            lower it to keep shallower columns, or set 0 to drop only negatives. Negative
+            water columns are always dropped regardless, being physically impossible.
         fieldwork_dates (Dict[str, list]): Dictionary of location name and a list of
             fieldwork days. All records on the fieldwork day are set to None.
         interpolate_method (str): String representing the interpolate method as in
             pd.Series.interpolate() method.
+
+    Returns:
+        Timeseries | Dataset | None: head (variable 'head', unit 'm asl').
     """
-    if fieldwork_dates is None:
-        fieldwork_dates = {}
+    return _apply(
+        "compensate", raw, barometric, alignment_period, threshold_wc,
+        fieldwork_dates, interpolate_method,
+    )
 
-    def _compensate_one(
-        raw: Timeseries, fieldwork_dates: list | None
-    ) -> Timeseries | None:
-        comp = Compensator(ts=raw, barometric=barometric)
-        compensated = comp.compensate(
-            alignment_period=alignment_period,
-            threshold_wc=threshold_wc,
-            fieldwork_dates=fieldwork_dates,
-        )
-        if compensated is not None and interpolate_method:
-            # .interpolate() called on Timeseries object is wrapped to return a
-            # Timeseries object from the original pandas.Series.interpolate().
-            return compensated.interpolate(method=interpolate_method)  # type: ignore[no-any-return]
 
-        else:
-            return compensated
+def water_column(
+    raw: Timeseries | Dataset,
+    barometric: Timeseries | float,
+    alignment_period: Literal[
+        "D", "ME", "SME", "MS", "YE", "YS", "h", "min", "s"
+    ] = "h",
+    threshold_wc: float | None = 0.025,
+    fieldwork_dates: dict | None = None,
+    interpolate_method: str | None = None,
+) -> Timeseries | Dataset | None:
+    """Barometrically compensate raw sensor pressure to the water column above the sensor.
 
-    if isinstance(raw, Timeseries):
-        dates = fieldwork_dates.get(raw.location)
-        return _compensate_one(raw, dates)
+    This is the first step of :func:`compensate` exposed on its own: subtract the
+    barometric pressure, convert to mH2O, mask fieldwork days, and drop out-of-water
+    records (see ``threshold_wc``) - without adding the sensor altitude, so the result is
+    the water column height in metres (variable 'water_column', unit 'm') rather than head.
 
-    elif isinstance(raw, Dataset):
-        compensated_series = []
-        for item in raw:
-            dates = fieldwork_dates.get(item.location)
-            compensated_series.append(_compensate_one(item, dates))
+    Parameters:
+        raw (Timeseries | Dataset): Raw sensor timeseries
+        barometric (Timeseries | float): Barometric pressure timeseries or a single
+            float value. If a float value is provided, it is assumed to be in cmH2O.
+        alignment_period (Literal['D', 'ME', 'SME', 'MS', 'YE', 'YS', 'h', 'min', 's']): The alignment period for the timeseries.
+            Default is 'h'. See pandas offset aliases for definitinos.
+        threshold_wc (float | None): Lower cutoff (in m) for the water column; records at
+            or below it are dropped. Defaults to 0.025 m (25 mm) and is always applied;
+            lower it to keep shallower columns, or set 0 to drop only negatives. Negative
+            water columns are always dropped regardless, being physically impossible.
+        fieldwork_dates (Dict[str, list]): Dictionary of location name and a list of
+            fieldwork days. All records on the fieldwork day are set to None.
+        interpolate_method (str): String representing the interpolate method as in
+            pd.Series.interpolate() method.
 
-        return raw.model_copy(update={"timeseries": compensated_series}, deep=True)
+    Returns:
+        Timeseries | Dataset | None: the water column height (variable 'water_column',
+            unit 'm').
+    """
+    return _apply(
+        "water_column", raw, barometric, alignment_period, threshold_wc,
+        fieldwork_dates, interpolate_method,
+    )

--- a/gensor/processing/compensation.py
+++ b/gensor/processing/compensation.py
@@ -207,7 +207,8 @@ def _apply(
 
     def _one(item: Timeseries, dates: list | None) -> Timeseries | None:
         comp = Compensator(ts=item, barometric=barometric)
-        result = getattr(comp, step)(
+        method = comp.water_column if step == "water_column" else comp.compensate
+        result = method(
             alignment_period=alignment_period,
             threshold_wc=threshold_wc,
             fieldwork_dates=dates,
@@ -259,8 +260,13 @@ def compensate(
         Timeseries | Dataset | None: head (variable 'head', unit 'm asl').
     """
     return _apply(
-        "compensate", raw, barometric, alignment_period, threshold_wc,
-        fieldwork_dates, interpolate_method,
+        "compensate",
+        raw,
+        barometric,
+        alignment_period,
+        threshold_wc,
+        fieldwork_dates,
+        interpolate_method,
     )
 
 
@@ -301,6 +307,11 @@ def water_column(
             unit 'm').
     """
     return _apply(
-        "water_column", raw, barometric, alignment_period, threshold_wc,
-        fieldwork_dates, interpolate_method,
+        "water_column",
+        raw,
+        barometric,
+        alignment_period,
+        threshold_wc,
+        fieldwork_dates,
+        interpolate_method,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gensor"
-version = "0.2.5"
+version = "0.3.0"
 description = "Library for handling groundwater sensor data."
 authors = ["Mateusz Zawadzki <zawadzkimat@outlook.com>"]
 repository = "https://github.com/zawadzkim/gensor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gensor"
-version = "0.3.0"
+version = "0.4.0"
 description = "Library for handling groundwater sensor data."
 authors = ["Mateusz Zawadzki <zawadzkimat@outlook.com>"]
 repository = "https://github.com/zawadzkim/gensor"

--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pydantic as pyd
 import pytest
 
-from gensor import compensate
+from gensor import compensate, water_column
 from gensor.core.timeseries import Timeseries
 
 
@@ -91,8 +91,84 @@ def test_missing_sensor_alt(synthetic_submerged_timeseries, barometric_value):
         compensate(raw=missing_sensor_alt, barometric=barometric_value)
 
 
+def test_threshold_wc_drops_negative_and_near_zero_water_columns():
+    """threshold_wc must drop near-zero AND negative water columns (out-of-water /
+    erroneous), not just those whose absolute value is small."""
+    idx = pd.date_range("2022-01-01", periods=5, freq="h", tz="UTC")
+    # baro = 1000 cmH2O; water columns (m): +5.0, +4.5, -0.02 (near zero), -0.5 (erroneous), +4.8
+    sensor = pd.Series([1500.0, 1450.0, 998.0, 950.0, 1480.0], index=idx)
+    ts = Timeseries(
+        ts=sensor, variable="pressure", unit="cmh2o",
+        location="PBX", sensor="S1", sensor_alt=30.0,
+    )
+
+    compensated = compensate(raw=ts, barometric=1000.0, threshold_wc=0.05)
+
+    # only the three positive-above-cutoff water columns survive (heads 35.0, 34.5, 34.8)
+    assert len(compensated.ts) == 3
+    assert (compensated.ts >= 30.0).all()
+    # the erroneous -0.5 m water column (head 29.5) must be gone
+    assert 29.5 not in set(compensated.ts.round(3))
+    # both the near-zero and the negative reading are recorded as dropped outliers
+    assert len(compensated.outliers) == 2
+
+
+def test_water_column_standalone():
+    """water_column() returns just the compensated water column (no sensor altitude)."""
+    idx = pd.date_range("2022-01-01", periods=4, freq="h", tz="UTC")
+    # baro = 1000 cmH2O; water columns (m): +5.0, +0.01 (< 25 mm), -0.3, +4.0
+    sensor = pd.Series([1500.0, 1001.0, 970.0, 1400.0], index=idx)
+    ts = Timeseries(
+        ts=sensor, variable="pressure", unit="cmh2o",
+        location="PBX", sensor="S1", sensor_alt=30.0,
+    )
+
+    wc = water_column(raw=ts, barometric=1000.0)
+
+    assert wc.variable == "water_column"
+    assert wc.unit == "m"
+    # same out-of-water filtering as compensate: only +5.0 and +4.0 survive
+    assert set(wc.ts.round(2)) == {5.0, 4.0}
+    assert len(wc.outliers) == 2
+
+
+def test_compensate_equals_water_column_plus_sensor_alt():
+    """compensate() head is exactly the water column plus the sensor altitude."""
+    idx = pd.date_range("2022-01-01", periods=4, freq="h", tz="UTC")
+    sensor = pd.Series([1500.0, 1001.0, 970.0, 1400.0], index=idx)
+    ts = Timeseries(
+        ts=sensor, variable="pressure", unit="cmh2o",
+        location="PBX", sensor="S1", sensor_alt=30.0,
+    )
+
+    wc = water_column(raw=ts, barometric=1000.0)
+    head = compensate(raw=ts, barometric=1000.0)
+
+    assert head.variable == "head"
+    assert head.unit == "m asl"
+    pd.testing.assert_series_equal(head.ts, wc.ts + 30.0, check_names=False)
+
+
+def test_default_threshold_drops_negative_water_columns():
+    """With no threshold_wc passed, the 25 mm default applies and drops negatives."""
+    idx = pd.date_range("2022-01-01", periods=4, freq="h", tz="UTC")
+    # baro = 1000 cmH2O; water columns (m): +5.0, +0.01 (< 25 mm), -0.3 (erroneous), +4.0
+    sensor = pd.Series([1500.0, 1001.0, 970.0, 1400.0], index=idx)
+    ts = Timeseries(
+        ts=sensor, variable="pressure", unit="cmh2o",
+        location="PBX", sensor="S1", sensor_alt=30.0,
+    )
+
+    compensated = compensate(raw=ts, barometric=1000.0)  # default threshold_wc = 0.025
+
+    # only +5.0 and +4.0 m survive (heads 35.0, 34.0); +0.01 and -0.3 are dropped
+    assert len(compensated.ts) == 2
+    assert set(compensated.ts.round(2)) == {35.0, 34.0}
+    assert len(compensated.outliers) == 2
+
+
 def test_mask_fieldwork_days(pb01a_fieldwork, pb01a_timeseries, baro_timeseries):
-    """Test removal of erroneous measurements with a mask of fieldwork events"""
+    """Fieldwork days are masked to NaN gaps and kept (not dropped) in the output."""
 
     comp_ts = compensate(
         raw=pb01a_timeseries,
@@ -100,4 +176,7 @@ def test_mask_fieldwork_days(pb01a_fieldwork, pb01a_timeseries, baro_timeseries)
         fieldwork_dates=pb01a_fieldwork,
     )
 
-    assert len(comp_ts.ts) == len(pb01a_timeseries.ts)
+    # the fieldwork day (2020-08-25) survives as NaN gaps rather than being removed
+    fieldwork_day = comp_ts.ts.loc["2020-08-25"]
+    assert len(fieldwork_day) > 0
+    assert fieldwork_day.isna().all()

--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -98,8 +98,12 @@ def test_threshold_wc_drops_negative_and_near_zero_water_columns():
     # baro = 1000 cmH2O; water columns (m): +5.0, +4.5, -0.02 (near zero), -0.5 (erroneous), +4.8
     sensor = pd.Series([1500.0, 1450.0, 998.0, 950.0, 1480.0], index=idx)
     ts = Timeseries(
-        ts=sensor, variable="pressure", unit="cmh2o",
-        location="PBX", sensor="S1", sensor_alt=30.0,
+        ts=sensor,
+        variable="pressure",
+        unit="cmh2o",
+        location="PBX",
+        sensor="S1",
+        sensor_alt=30.0,
     )
 
     compensated = compensate(raw=ts, barometric=1000.0, threshold_wc=0.05)
@@ -119,8 +123,12 @@ def test_water_column_standalone():
     # baro = 1000 cmH2O; water columns (m): +5.0, +0.01 (< 25 mm), -0.3, +4.0
     sensor = pd.Series([1500.0, 1001.0, 970.0, 1400.0], index=idx)
     ts = Timeseries(
-        ts=sensor, variable="pressure", unit="cmh2o",
-        location="PBX", sensor="S1", sensor_alt=30.0,
+        ts=sensor,
+        variable="pressure",
+        unit="cmh2o",
+        location="PBX",
+        sensor="S1",
+        sensor_alt=30.0,
     )
 
     wc = water_column(raw=ts, barometric=1000.0)
@@ -137,8 +145,12 @@ def test_compensate_equals_water_column_plus_sensor_alt():
     idx = pd.date_range("2022-01-01", periods=4, freq="h", tz="UTC")
     sensor = pd.Series([1500.0, 1001.0, 970.0, 1400.0], index=idx)
     ts = Timeseries(
-        ts=sensor, variable="pressure", unit="cmh2o",
-        location="PBX", sensor="S1", sensor_alt=30.0,
+        ts=sensor,
+        variable="pressure",
+        unit="cmh2o",
+        location="PBX",
+        sensor="S1",
+        sensor_alt=30.0,
     )
 
     wc = water_column(raw=ts, barometric=1000.0)
@@ -155,8 +167,12 @@ def test_default_threshold_drops_negative_water_columns():
     # baro = 1000 cmH2O; water columns (m): +5.0, +0.01 (< 25 mm), -0.3 (erroneous), +4.0
     sensor = pd.Series([1500.0, 1001.0, 970.0, 1400.0], index=idx)
     ts = Timeseries(
-        ts=sensor, variable="pressure", unit="cmh2o",
-        location="PBX", sensor="S1", sensor_alt=30.0,
+        ts=sensor,
+        variable="pressure",
+        unit="cmh2o",
+        location="PBX",
+        sensor="S1",
+        sensor_alt=30.0,
     )
 
     compensated = compensate(raw=ts, barometric=1000.0)  # default threshold_wc = 0.025

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -109,6 +109,34 @@ def test_filter_with_attribute_as_list(synthetic_dataset):
     assert "Sensor 3" in sensors_in_result
 
 
+def test_filter_exclude_single_location(synthetic_dataset):
+    """exclude= drops timeseries matching the given attribute."""
+    result = synthetic_dataset.filter(exclude={"location": "Station A"})
+    assert isinstance(result, Timeseries)
+    assert result.location == "Station B"
+
+
+def test_filter_exclude_location_list(synthetic_dataset):
+    """exclude= accepts a list (drop any location in the list)."""
+    result = synthetic_dataset.filter(exclude={"location": ["Station A", "Station B"]})
+    assert isinstance(result, Dataset)
+    assert len(result) == 0
+
+
+def test_filter_exclude_attribute_pair_is_anded(synthetic_dataset):
+    """All conditions in exclude must match (AND): only Station B / Sensor 2 is dropped."""
+    result = synthetic_dataset.filter(exclude={"location": "Station B", "sensor": "Sensor 2"})
+    assert isinstance(result, Timeseries)
+    assert result.location == "Station A"
+
+
+def test_filter_include_and_exclude_combined(synthetic_dataset):
+    """exclude= is applied on top of the include filters."""
+    result = synthetic_dataset.filter(variable="pressure", exclude={"location": "Station A"})
+    assert isinstance(result, Timeseries)
+    assert result.location == "Station B"
+
+
 def test_getitem_by_index_still_returns_timeseries(synthetic_dataset):
     """Integer indexing keeps working and returns a Timeseries reference."""
     assert isinstance(synthetic_dataset[0], Timeseries)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -107,5 +107,54 @@ def test_filter_with_attribute_as_list(synthetic_dataset):
     assert "Sensor 3" in sensors_in_result
 
 
+def test_getitem_by_index_still_returns_timeseries(synthetic_dataset):
+    """Integer indexing keeps working and returns a Timeseries reference."""
+    assert isinstance(synthetic_dataset[0], Timeseries)
+
+
+def test_getitem_by_location_single(synthetic_dataset):
+    """A location with one matching timeseries returns a Timeseries."""
+    ts = synthetic_dataset["Station A"]
+    assert isinstance(ts, Timeseries)
+    assert ts.location == "Station A"
+
+
+def test_getitem_by_location_multiple(synthetic_dataset):
+    """A location with several timeseries returns a Dataset of them."""
+    synthetic_dataset.add(
+        synthetic_dataset[0].model_copy(
+            update={"variable": "temperature", "unit": "degc"}
+        )
+    )
+    result = synthetic_dataset["Station A"]
+    assert isinstance(result, Dataset)
+    assert len(result) == 2
+    assert {ts.variable for ts in result} == {"pressure", "temperature"}
+
+
+def test_getitem_by_location_missing_raises_keyerror(synthetic_dataset):
+    """Indexing an unknown location raises KeyError (dict-like)."""
+    with pytest.raises(KeyError):
+        synthetic_dataset["Non-existent Station"]
+
+
+def test_getitem_by_location_list(synthetic_dataset):
+    """A list of locations returns a Dataset with the matching timeseries."""
+    result = synthetic_dataset[["Station A", "Station B"]]
+    assert isinstance(result, Dataset)
+    assert len(result) == 2
+
+
+def test_get_locations_is_unique(synthetic_dataset):
+    """get_locations() de-duplicates (one entry per location, as documented)."""
+    synthetic_dataset.add(
+        synthetic_dataset[0].model_copy(
+            update={"variable": "temperature", "unit": "degc"}
+        )
+    )
+    locations = synthetic_dataset.get_locations()
+    assert sorted(locations) == ["Station A", "Station B"]
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from gensor.core.dataset import Coverage, CoverageDiff, Dataset, diff
+from gensor.core.dataset import Coverage, CoverageDiff, Dataset, Where, diff
 from gensor.core.timeseries import Timeseries
 from gensor.io.read import read_from_sql
 
@@ -109,30 +109,123 @@ def test_filter_with_attribute_as_list(synthetic_dataset):
     assert "Sensor 3" in sensors_in_result
 
 
-def test_filter_exclude_single_location(synthetic_dataset):
-    """exclude= drops timeseries matching the given attribute."""
-    result = synthetic_dataset.filter(exclude={"location": "Station A"})
+def test_filter_negate_single_location(synthetic_dataset):
+    """A ``~``-prefixed value drops timeseries with that attribute value."""
+    result = synthetic_dataset.filter(location="~Station A")
     assert isinstance(result, Timeseries)
     assert result.location == "Station B"
 
 
-def test_filter_exclude_location_list(synthetic_dataset):
-    """exclude= accepts a list (drop any location in the list)."""
-    result = synthetic_dataset.filter(exclude={"location": ["Station A", "Station B"]})
+def test_filter_negate_location_list(synthetic_dataset):
+    """A list of ``~``-prefixed values drops any location in the list."""
+    result = synthetic_dataset.filter(location=["~Station A", "~Station B"])
     assert isinstance(result, Dataset)
     assert len(result) == 0
 
 
-def test_filter_exclude_attribute_pair_is_anded(synthetic_dataset):
-    """All conditions in exclude must match (AND): only Station B / Sensor 2 is dropped."""
-    result = synthetic_dataset.filter(exclude={"location": "Station B", "sensor": "Sensor 2"})
+def test_filter_negate_by_kwarg(synthetic_dataset):
+    """Negation works on keyword attributes too (e.g. drop a single sensor)."""
+    result = synthetic_dataset.filter(sensor="~Sensor 2")
     assert isinstance(result, Timeseries)
     assert result.location == "Station A"
 
 
-def test_filter_include_and_exclude_combined(synthetic_dataset):
-    """exclude= is applied on top of the include filters."""
-    result = synthetic_dataset.filter(variable="pressure", exclude={"location": "Station A"})
+def test_filter_include_and_negate_combined(synthetic_dataset):
+    """Positive and negated filters are AND-ed across attributes."""
+    result = synthetic_dataset.filter(variable="pressure", location="~Station A")
+    assert isinstance(result, Timeseries)
+    assert result.location == "Station B"
+
+
+def test_filter_mixed_include_and_negate_one_attribute(synthetic_dataset):
+    """Positive and negated values may be mixed within a single attribute."""
+    result = synthetic_dataset.filter(location=["Station A", "Station B", "~Station A"])
+    assert isinstance(result, Timeseries)
+    assert result.location == "Station B"
+
+
+def test_filter_with_where_predicate_negated_combination(synthetic_dataset):
+    """filter() accepts Where predicates; ~Where(a, b) drops only the (a AND b) series."""
+    result = synthetic_dataset.filter(~Where(location="Station A", sensor="Sensor 1"))
+    assert isinstance(result, Timeseries)
+    assert result.location == "Station B"
+
+
+def test_pop_removes_and_returns(synthetic_dataset):
+    """pop() returns the matching timeseries and removes it from the dataset."""
+    n = len(synthetic_dataset)
+    popped = synthetic_dataset.pop(location="Station A")
+    assert isinstance(popped, Timeseries)
+    assert popped.location == "Station A"
+    assert len(synthetic_dataset) == n - 1
+    assert "Station A" not in synthetic_dataset
+
+
+def test_pop_returns_reference_for_roundtrip(synthetic_dataset):
+    """pop() returns the live object (not a copy); edit then add() round-trips."""
+    ts = synthetic_dataset.pop(location="Station A")
+    ts.ts = ts.ts * 0 + 42.0
+    synthetic_dataset.add(ts)
+    assert (synthetic_dataset["Station A"].ts == 42.0).all()
+
+
+def test_loc_slices_every_timeseries(pb01a_timeseries, baro_timeseries):
+    """ds.loc[start:end] slices each timeseries by label and returns a new Dataset."""
+    ds = Dataset(timeseries=[pb01a_timeseries, baro_timeseries[0]])
+    start, end = "2021-01-01", "2021-06-30"
+
+    sub = ds.loc[start:end]
+
+    assert isinstance(sub, Dataset)
+    assert len(sub) == len(ds)
+    for ts in sub:
+        assert str(ts.ts.index.min().date()) >= start
+        assert str(ts.ts.index.max().date()) <= end
+    # original is untouched
+    assert pb01a_timeseries.ts.index.min() < pd.Timestamp(start, tz="UTC")
+
+
+def test_loc_scalar_key_raises(synthetic_dataset):
+    """A point lookup (scalar per series) is rejected with a clear message."""
+    ts0 = synthetic_dataset[0].ts.index[0]
+    with pytest.raises(TypeError, match="label slice"):
+        synthetic_dataset.loc[ts0]
+
+
+def test_pop_no_match_removes_nothing(synthetic_dataset):
+    """pop() with no match returns an empty Dataset and leaves the dataset unchanged."""
+    n = len(synthetic_dataset)
+    result = synthetic_dataset.pop(location="Nonexistent")
+    assert isinstance(result, Dataset)
+    assert len(result) == 0
+    assert len(synthetic_dataset) == n
+
+
+def test_filter_negated_combination_spares_partial_match(synthetic_dataset):
+    """~Where(a, b) must NOT drop series that match only some of the combined conditions."""
+    # No series is (Station A AND Sensor 2), so the negated combination drops nothing.
+    result = synthetic_dataset.filter(~Where(location="Station A", sensor="Sensor 2"))
+    assert isinstance(result, Dataset)
+    assert len(result) == 2
+
+
+def test_filter_union_of_negated_predicates(synthetic_dataset):
+    """Several negated predicates AND together to remove the union of their matches."""
+    result = synthetic_dataset.filter(~Where(location="Station A"), ~Where(location="Station B"))
+    assert isinstance(result, Dataset)
+    assert len(result) == 0
+
+
+def test_where_or_combination(synthetic_dataset):
+    """Where supports | (or): keep series matching either branch."""
+    result = synthetic_dataset.filter(Where(location="Station A") | Where(location="Station B"))
+    assert isinstance(result, Dataset)
+    assert len(result) == 2
+
+
+def test_where_and_with_keyword_filter(synthetic_dataset):
+    """A positional Where is AND-ed with the keyword filters in the same call."""
+    result = synthetic_dataset.filter(~Where(location="Station A"), variable="pressure")
     assert isinstance(result, Timeseries)
     assert result.location == "Station B"
 
@@ -292,6 +385,16 @@ def test_coverage_table(synthetic_dataset):
     assert len(coverage.table) == len(synthetic_dataset)
     assert set(coverage.table["location"]) == {"Station A", "Station B"}
     assert (coverage.table["records"] > 0).all()
+
+
+def test_info_table(synthetic_dataset):
+    """Dataset.info is a per-timeseries metadata table."""
+    info = synthetic_dataset.info
+    assert isinstance(info, pd.DataFrame)
+    assert list(info.columns) == ["location", "variable", "sensor", "records", "start", "end"]
+    assert len(info) == len(synthetic_dataset)
+    assert set(info["location"]) == {"Station A", "Station B"}
+    assert (info["records"] > 0).all()
 
 
 def test_coverage_plot_returns_fig_ax(synthetic_dataset):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from gensor.core.dataset import Coverage, Dataset
+from gensor.core.dataset import Coverage, CoverageDiff, Dataset, diff
 from gensor.core.timeseries import Timeseries
 from gensor.io.read import read_from_sql
 
@@ -302,6 +302,50 @@ def test_coverage_plot_returns_fig_ax(synthetic_dataset):
     fig, ax = synthetic_dataset.coverage.plot()
     assert fig is not None
     assert len(ax.get_yticks()) == len(synthetic_dataset.get_locations())
+    matplotlib.pyplot.close(fig)
+
+
+def test_diff_table_and_status(synthetic_dataset):
+    """Dataset.diff aligns by (location, variable) and reports per-dataset coverage."""
+    other = Dataset(timeseries=[synthetic_dataset[0].model_copy(deep=True)])  # Station A only
+    result = synthetic_dataset.diff(other, labels=["full", "partial"])
+
+    assert isinstance(result, CoverageDiff)
+    for col in [("full", "records"), ("partial", "records"), ("summary", "status"),
+                ("summary", "present")]:
+        assert col in result.table.columns
+
+    status = {idx[0]: val for idx, val in result.table[("summary", "status")].items()}
+    present = {idx[0]: val for idx, val in result.table[("summary", "present")].items()}
+    assert status["Station A"] == "identical"
+    assert status["Station B"] == "only full"
+    assert present["Station A"] == 2
+    assert present["Station B"] == 1
+
+
+def test_diff_module_function_with_list_autolabels(synthetic_dataset):
+    """diff() accepts a list and auto-labels ds0, ds1, ..."""
+    other = Dataset(timeseries=[synthetic_dataset[0].model_copy(deep=True)])
+    result = diff([synthetic_dataset, other])
+    assert ("ds0", "records") in result.table.columns
+    assert ("ds1", "records") in result.table.columns
+
+
+def test_diff_requires_at_least_two(synthetic_dataset):
+    with pytest.raises(ValueError):
+        diff({"only": synthetic_dataset})
+
+
+def test_diff_plot_returns_fig_ax(synthetic_dataset):
+    """CoverageDiff.plot() returns a (fig, ax) with one row per aligned key."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    other = Dataset(timeseries=[synthetic_dataset[0].model_copy(deep=True)])
+    comparison = synthetic_dataset.diff(other, labels=["a", "b"])
+    fig, ax = comparison.plot()
+    assert fig is not None
+    assert len(ax.get_yticks()) == len(comparison.keys)  # one row per aligned (location, variable)
     matplotlib.pyplot.close(fig)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -211,14 +211,18 @@ def test_filter_negated_combination_spares_partial_match(synthetic_dataset):
 
 def test_filter_union_of_negated_predicates(synthetic_dataset):
     """Several negated predicates AND together to remove the union of their matches."""
-    result = synthetic_dataset.filter(~Where(location="Station A"), ~Where(location="Station B"))
+    result = synthetic_dataset.filter(
+        ~Where(location="Station A"), ~Where(location="Station B")
+    )
     assert isinstance(result, Dataset)
     assert len(result) == 0
 
 
 def test_where_or_combination(synthetic_dataset):
     """Where supports | (or): keep series matching either branch."""
-    result = synthetic_dataset.filter(Where(location="Station A") | Where(location="Station B"))
+    result = synthetic_dataset.filter(
+        Where(location="Station A") | Where(location="Station B")
+    )
     assert isinstance(result, Dataset)
     assert len(result) == 2
 
@@ -391,7 +395,14 @@ def test_info_table(synthetic_dataset):
     """Dataset.info is a per-timeseries metadata table."""
     info = synthetic_dataset.info
     assert isinstance(info, pd.DataFrame)
-    assert list(info.columns) == ["location", "variable", "sensor", "records", "start", "end"]
+    assert list(info.columns) == [
+        "location",
+        "variable",
+        "sensor",
+        "records",
+        "start",
+        "end",
+    ]
     assert len(info) == len(synthetic_dataset)
     assert set(info["location"]) == {"Station A", "Station B"}
     assert (info["records"] > 0).all()
@@ -410,12 +421,18 @@ def test_coverage_plot_returns_fig_ax(synthetic_dataset):
 
 def test_diff_table_and_status(synthetic_dataset):
     """Dataset.diff aligns by (location, variable) and reports per-dataset coverage."""
-    other = Dataset(timeseries=[synthetic_dataset[0].model_copy(deep=True)])  # Station A only
+    other = Dataset(
+        timeseries=[synthetic_dataset[0].model_copy(deep=True)]
+    )  # Station A only
     result = synthetic_dataset.diff(other, labels=["full", "partial"])
 
     assert isinstance(result, CoverageDiff)
-    for col in [("full", "records"), ("partial", "records"), ("summary", "status"),
-                ("summary", "present")]:
+    for col in [
+        ("full", "records"),
+        ("partial", "records"),
+        ("summary", "status"),
+        ("summary", "present"),
+    ]:
         assert col in result.table.columns
 
     status = {idx[0]: val for idx, val in result.table[("summary", "status")].items()}
@@ -448,7 +465,9 @@ def test_diff_plot_returns_fig_ax(synthetic_dataset):
     comparison = synthetic_dataset.diff(other, labels=["a", "b"])
     fig, ax = comparison.plot()
     assert fig is not None
-    assert len(ax.get_yticks()) == len(comparison.keys)  # one row per aligned (location, variable)
+    assert len(ax.get_yticks()) == len(
+        comparison.keys
+    )  # one row per aligned (location, variable)
     matplotlib.pyplot.close(fig)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -134,6 +134,32 @@ def test_getitem_by_location_multiple(synthetic_dataset):
     assert {ts.variable for ts in result} == {"pressure", "temperature"}
 
 
+def test_getitem_by_location_and_variable_tuple(synthetic_dataset):
+    """(location, variable) tuple indexing narrows to a single Timeseries."""
+    synthetic_dataset.add(
+        synthetic_dataset[0].model_copy(
+            update={"variable": "temperature", "unit": "degc"}
+        )
+    )
+    ts = synthetic_dataset["Station A", "pressure"]
+    assert isinstance(ts, Timeseries)
+    assert ts.location == "Station A"
+    assert ts.variable == "pressure"
+
+
+def test_getitem_tuple_with_unit(synthetic_dataset):
+    """(location, variable, unit) tuple is supported too."""
+    ts = synthetic_dataset["Station A", "pressure", "cmh2o"]
+    assert isinstance(ts, Timeseries)
+    assert ts.unit == "cmh2o"
+
+
+def test_getitem_tuple_missing_raises_keyerror(synthetic_dataset):
+    """A tuple with no match raises KeyError."""
+    with pytest.raises(KeyError):
+        synthetic_dataset["Station A", "conductivity"]
+
+
 def test_getitem_by_location_missing_raises_keyerror(synthetic_dataset):
     """Indexing an unknown location raises KeyError (dict-like)."""
     with pytest.raises(KeyError):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,9 @@
+import pandas as pd
 import pytest
 
 from gensor.core.dataset import Dataset
 from gensor.core.timeseries import Timeseries
+from gensor.io.read import read_from_sql
 
 
 def test_add_timeseries_to_dataset(pb01a_timeseries, baro_timeseries):
@@ -145,6 +147,37 @@ def test_getitem_by_location_list(synthetic_dataset):
     assert len(result) == 2
 
 
+def test_contains_location(synthetic_dataset):
+    """`location in dataset` checks membership by location name."""
+    assert "Station A" in synthetic_dataset
+    assert "Station B" in synthetic_dataset
+    assert "Non-existent Station" not in synthetic_dataset
+
+
+def test_one_returns_single_timeseries(synthetic_dataset):
+    """one() returns a single Timeseries when exactly one matches."""
+    ts = synthetic_dataset.one(location="Station A")
+    assert isinstance(ts, Timeseries)
+    assert ts.location == "Station A"
+
+
+def test_one_raises_when_multiple_match(synthetic_dataset):
+    """one() raises when more than one timeseries matches."""
+    synthetic_dataset.add(
+        synthetic_dataset[0].model_copy(
+            update={"variable": "temperature", "unit": "degc"}
+        )
+    )
+    with pytest.raises(ValueError):
+        synthetic_dataset.one(location="Station A")
+
+
+def test_one_raises_when_no_match(synthetic_dataset):
+    """one() raises when nothing matches."""
+    with pytest.raises(ValueError):
+        synthetic_dataset.one(location="Non-existent Station")
+
+
 def test_get_locations_is_unique(synthetic_dataset):
     """get_locations() de-duplicates (one entry per location, as documented)."""
     synthetic_dataset.add(
@@ -154,6 +187,47 @@ def test_get_locations_is_unique(synthetic_dataset):
     )
     locations = synthetic_dataset.get_locations()
     assert sorted(locations) == ["Station A", "Station B"]
+
+
+def test_to_sql_handles_large_series(db):
+    """to_sql() must persist series larger than SQLite's bound-variable limit."""
+    n = 300_000  # exceeds SQLite's bound-variable limit for a single multi-row INSERT
+    idx = pd.date_range("2020-01-01", periods=n, freq="s", tz="UTC")
+    big = Timeseries(
+        ts=pd.Series(range(n), index=idx, dtype=float),
+        variable="pressure",
+        unit="cmh2o",
+        location="BigStation",
+        sensor="S1",
+    )
+
+    Dataset(timeseries=[big]).to_sql(db)  # must not raise "too many SQL variables"
+
+    reloaded = read_from_sql(db, load_all=True)
+    ts = reloaded if isinstance(reloaded, Timeseries) else reloaded[0]
+    assert len(ts.ts) == n
+
+
+def test_to_sql_skips_empty_timeseries(db, synthetic_submerged_timeseries):
+    """to_sql() must not crash on empty timeseries (their start/end are NaT)."""
+    empty = synthetic_submerged_timeseries.model_copy(
+        update={
+            "ts": pd.Series([], index=pd.DatetimeIndex([], tz="UTC"), dtype=float),
+            "location": "EmptyLoc",
+        }
+    )
+    ds = Dataset(timeseries=[synthetic_submerged_timeseries, empty])
+
+    ds.to_sql(db)  # should skip the empty one rather than raise on NaT.strftime
+
+    reloaded = read_from_sql(db, load_all=True)
+    locations = (
+        reloaded.get_locations()
+        if isinstance(reloaded, Dataset)
+        else [reloaded.location]
+    )
+    assert "Station A" in locations
+    assert "EmptyLoc" not in locations
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from gensor.core.dataset import Dataset
+from gensor.core.dataset import Coverage, Dataset
 from gensor.core.timeseries import Timeseries
 from gensor.io.read import read_from_sql
 
@@ -282,6 +282,27 @@ def test_to_sql_skips_empty_timeseries(db, synthetic_submerged_timeseries):
     )
     assert "Station A" in locations
     assert "EmptyLoc" not in locations
+
+
+def test_coverage_table(synthetic_dataset):
+    """Dataset.coverage exposes a per-timeseries table."""
+    coverage = synthetic_dataset.coverage
+    assert isinstance(coverage, Coverage)
+    assert list(coverage.table.columns) == Coverage.columns
+    assert len(coverage.table) == len(synthetic_dataset)
+    assert set(coverage.table["location"]) == {"Station A", "Station B"}
+    assert (coverage.table["records"] > 0).all()
+
+
+def test_coverage_plot_returns_fig_ax(synthetic_dataset):
+    """Dataset.coverage.plot() returns a (fig, ax) with one row per location."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    fig, ax = synthetic_dataset.coverage.plot()
+    assert fig is not None
+    assert len(ax.get_yticks()) == len(synthetic_dataset.get_locations())
+    matplotlib.pyplot.close(fig)
 
 
 if __name__ == "__main__":

--- a/tests/test_parser_robustness.py
+++ b/tests/test_parser_robustness.py
@@ -53,22 +53,33 @@ def test_vanessen_explicit_location_sensor_override():
     assert ts.sensor == "XYZ001"
 
 
-def test_vanessen_explicit_metadata_when_regex_fails(tmp_path):
-    """When the header has no regex-matchable location/sensor, explicit kwargs let it parse."""
+def test_vanessen_uses_labelled_field_when_regex_fails(tmp_path):
+    """A location/serial that doesn't match the regex is taken verbatim from the
+    labelled header field ('Location' / 'Serial number') - no override needed."""
     text, enc = _read_text(pb01a)
     masked = text.replace("PB01A_moni_AV319", "neerijse").replace("AV319", "K5171")
     f = tmp_path / "neerijse.CSV"
     f.write_text(masked, encoding=enc)
 
-    # Without overrides the location/sensor cannot be determined -> file skipped.
-    assert len(read_from_csv(f, file_format="vanessen")) == 0
-
-    # With explicit overrides the file parses.
-    ts = _as_timeseries(
-        read_from_csv(f, file_format="vanessen", location="neerijse", sensor="K5171")
-    )
+    ts = _as_timeseries(read_from_csv(f, file_format="vanessen"))
     assert ts.location == "neerijse"
     assert ts.sensor == "K5171"
+
+
+def test_vanessen_skipped_when_field_missing_then_override(tmp_path):
+    """When the labelled 'Location' field is absent the file is skipped, but an
+    explicit location= override still lets it parse."""
+    text, enc = _read_text(pb01a)
+    masked = "\n".join(ln for ln in text.splitlines() if "Location" not in ln) + "\n"
+    f = tmp_path / "no_location.CSV"
+    f.write_text(masked, encoding=enc)
+
+    # No 'Location' field and the name isn't regex-matchable -> skipped.
+    assert len(read_from_csv(f, file_format="vanessen")) == 0
+
+    # Explicit override supplies the missing location.
+    ts = _as_timeseries(read_from_csv(f, file_format="vanessen", location="neerijse"))
+    assert ts.location == "neerijse"
 
 
 def test_vanessen_semicolon_delimited(tmp_path):

--- a/tests/test_parser_robustness.py
+++ b/tests/test_parser_robustness.py
@@ -47,7 +47,9 @@ def test_vanessen_single_letter_serial(tmp_path):
 def test_vanessen_explicit_location_sensor_override():
     """Explicit location/sensor kwargs should win over the regex extraction."""
     ts = _as_timeseries(
-        read_from_csv(pb01a, file_format="vanessen", location="CUSTOMLOC", sensor="XYZ001")
+        read_from_csv(
+            pb01a, file_format="vanessen", location="CUSTOMLOC", sensor="XYZ001"
+        )
     )
     assert ts.location == "CUSTOMLOC"
     assert ts.sensor == "XYZ001"

--- a/tests/test_parser_robustness.py
+++ b/tests/test_parser_robustness.py
@@ -1,0 +1,90 @@
+"""Tests for van Essen parser robustness and explicit metadata overrides."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gensor.core.dataset import Dataset
+from gensor.io.read import read_from_csv
+from gensor.parse.utils import detect_encoding
+from gensor.testdata import pb01a
+
+
+def _read_text(path: Path) -> tuple[str, str]:
+    enc = detect_encoding(path, num_bytes=10_000)
+    return Path(path).read_text(encoding=enc), enc
+
+
+def _as_timeseries(result):
+    return result[0] if isinstance(result, Dataset) else result
+
+
+def test_vanessen_parses_without_end_marker(tmp_path):
+    """Diver-Office exports sometimes omit the 'END OF DATA FILE' trailer."""
+    text, enc = _read_text(pb01a)
+    assert "END OF DATA" in text  # the bundled file has it
+    truncated = text[: text.index("END OF DATA")].rstrip() + "\n"
+    f = tmp_path / "no_marker.CSV"
+    f.write_text(truncated, encoding=enc)
+
+    result = read_from_csv(f, file_format="vanessen")
+    assert isinstance(result, Dataset)
+    assert len(result) == 2
+
+
+def test_vanessen_single_letter_serial(tmp_path):
+    """The default serial pattern should also match single-letter serials (e.g. W1619)."""
+    text, enc = _read_text(pb01a)
+    swapped = text.replace("AV319", "W1619").replace("PB01A", "PB16D")
+    f = tmp_path / "single_letter.CSV"
+    f.write_text(swapped, encoding=enc)
+
+    ts = _as_timeseries(read_from_csv(f, file_format="vanessen"))
+    assert ts.sensor == "W1619"
+    assert ts.location == "PB16D"
+
+
+def test_vanessen_explicit_location_sensor_override():
+    """Explicit location/sensor kwargs should win over the regex extraction."""
+    ts = _as_timeseries(
+        read_from_csv(pb01a, file_format="vanessen", location="CUSTOMLOC", sensor="XYZ001")
+    )
+    assert ts.location == "CUSTOMLOC"
+    assert ts.sensor == "XYZ001"
+
+
+def test_vanessen_explicit_metadata_when_regex_fails(tmp_path):
+    """When the header has no regex-matchable location/sensor, explicit kwargs let it parse."""
+    text, enc = _read_text(pb01a)
+    masked = text.replace("PB01A_moni_AV319", "neerijse").replace("AV319", "K5171")
+    f = tmp_path / "neerijse.CSV"
+    f.write_text(masked, encoding=enc)
+
+    # Without overrides the location/sensor cannot be determined -> file skipped.
+    assert len(read_from_csv(f, file_format="vanessen")) == 0
+
+    # With explicit overrides the file parses.
+    ts = _as_timeseries(
+        read_from_csv(f, file_format="vanessen", location="neerijse", sensor="K5171")
+    )
+    assert ts.location == "neerijse"
+    assert ts.sensor == "K5171"
+
+
+def test_vanessen_semicolon_delimited(tmp_path):
+    """Some exports use ';' as the column separator in the data block."""
+    text, enc = _read_text(pb01a)
+    lines = text.splitlines()
+    out = []
+    in_data = False
+    for ln in lines:
+        if ln.startswith("Date/time"):
+            in_data = True
+        if in_data and not ln.startswith("END"):
+            ln = ln.replace(",", ";")
+        out.append(ln)
+    f = tmp_path / "semicolon.CSV"
+    f.write_text("\n".join(out) + "\n", encoding=enc)
+
+    result = read_from_csv(f, file_format="vanessen")
+    assert len(result) == 2

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -44,3 +44,54 @@ def test_dataset_plot(synthetic_dataset):
         assert ax.get_xlabel() == "Time"
 
     plt.close(fig)
+
+
+def test_dataset_plot_facet_location(synthetic_dataset):
+    """facet='location' returns a figure per variable, one panel per location."""
+    result = synthetic_dataset.plot(facet="location", ncols=5)
+
+    # synthetic_dataset has a single variable (pressure) -> one figure
+    assert isinstance(result, dict)
+    assert set(result) == {ts.variable for ts in synthetic_dataset.timeseries}
+
+    fig, axes = result["pressure"]
+    assert isinstance(fig, plt.Figure)
+    locations = synthetic_dataset.get_locations()
+    # every location gets a (titled) panel; the rest of the grid is hidden
+    visible = [ax for ax in axes if ax.get_visible()]
+    assert len(visible) == len(locations)
+    assert {ax.get_title() for ax in visible} == set(locations)
+
+    for fig, _ in result.values():
+        plt.close(fig)
+
+
+def test_dataset_plot_facet_location_legend_by_sensor(synthetic_submerged_timeseries):
+    """A panel with >1 sensor shows a legend labelled by serial; single-series panels don't."""
+    from gensor.core.dataset import Dataset
+
+    ts_a1 = synthetic_submerged_timeseries  # location 'Station A', sensor 'Sensor 1'
+    ts_a2 = ts_a1.model_copy(update={"sensor": "Sensor X"})  # same location, 2nd sensor
+    ts_b = ts_a1.model_copy(update={"location": "Station B", "sensor": "Sensor 2"})
+    ds = Dataset(timeseries=[ts_a1, ts_a2, ts_b])
+
+    fig, axes = ds.plot(facet="location")["pressure"]
+    by_loc = {ax.get_title(): ax for ax in axes if ax.get_visible()}
+
+    # Station A has two sensors -> legend by serial; Station B has one -> no legend
+    leg_a = by_loc["Station A"].get_legend()
+    assert leg_a is not None
+    assert {t.get_text() for t in leg_a.get_texts()} == {"Sensor 1", "Sensor X"}
+    assert by_loc["Station B"].get_legend() is None
+
+    plt.close(fig)
+
+
+def test_dataset_plot_facet_location_sharex(synthetic_dataset):
+    """sharex=True aligns every location panel to the same (full) x-range."""
+    fig, axes = synthetic_dataset.plot(facet="location", sharex=True)["pressure"]
+    drawn = [ax for ax in axes if ax.get_visible() and ax.lines]
+    assert len(drawn) >= 2
+    xlims = {ax.get_xlim() for ax in drawn}
+    assert len(xlims) == 1  # all panels share identical x-limits
+    plt.close(fig)


### PR DESCRIPTION
Release **0.4.0** (bumps `version` in `pyproject.toml`; merging to `main` deploys to PyPI).

## Highlights

**Filtering**
- `~`-prefixed values negate in `Dataset.filter` (`filter(location="~PB16D")`); mix positive/negated within and across attributes.
- Composable `Where` predicate (`& | ~`) for combined/cross-attribute conditions, e.g. `filter(~Where(location="PB03B", sensor="AV319"))`.
- Removed the `exclude=` dict (superseded).

**Dataset API**
- `pop(...)` — same selection as `filter`, but removes the matches and returns live references (extract → edit → `add()`).
- `info` — per-series metadata table; now the single source feeding `coverage` (adds derived `duration`) and `gensor.diff`/`CoverageDiff`.
- `loc[start:end]` — label slice forwarded to every timeseries → new sliced Dataset.
- `plot(facet="location", ncols=, sharex=)` — grid of one panel per location (separate figure per variable); empty locations keep an empty panel; legend only when several sensors share a panel (labelled by serial). `facet="variable"` remains the default.
- (Already on dev since 0.3.0: `coverage` table+timeline, `gensor.diff`, robust van Essen parser + header location/serial, `(location, variable[, unit])` indexing, `__contains__`, `one()`, robust `to_sql`.)

**Compensation (bug fix)**
- Out-of-water filtering is now a **signed** cutoff: negative water columns are always dropped (the old `.abs()` wrongly kept large-magnitude negatives), and the near-zero band at/below `threshold_wc` is removed. `threshold_wc` now defaults to **25 mm** and always applies.
- New `water_column(...)` (and `Compensator.water_column`) exposes the first compensation step (water column above sensor, m) on its own; `compensate(...)` builds on it.

See `CHANGELOG.md` for the full list.

## Testing
- `pytest`: **95 passed** locally.
- ruff/mypy/mkdocs validated by CI (local tooling versions differ from the pinned hooks, so CI is authoritative here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)