### PR TITLE
ci: fix release/docs deploy triggers (gate to QC success on main)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,9 +14,7 @@ permissions:
 jobs:
   build_mkdocs:
     # Only deploy docs after Quality control SUCCEEDS on main - not on PRs or dev pushes.
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,12 +13,17 @@ permissions:
 
 jobs:
   build_mkdocs:
+    # Only deploy docs after Quality control SUCCEEDS on main - not on PRs or dev pushes.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Set up Poetry environment

--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -3,8 +3,30 @@ name: Quality control
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [dev, main]
 
 jobs:
+  tag-check:
+    # On a push to dev, report whether the current version already has a release tag,
+    # as a reminder to bump before merging to main. Informational only - never releases.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Warn if the version tag already exists
+        run: |
+          version=$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          git fetch --tags --quiet
+          if git rev-parse "v${version}" >/dev/null 2>&1; then
+            echo "::warning::Version v${version} already has a tag; bump the version before merging to main to publish a release."
+          else
+            echo "Version v${version} has no tag yet - it will be released on merge to main."
+          fi
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-deploy-to-pypi.yml
+++ b/.github/workflows/release-deploy-to-pypi.yml
@@ -13,9 +13,7 @@ jobs:
   publish:
     # Only release after Quality control SUCCEEDS on main (i.e. a merge to main).
     # Never on pull requests or on pushes to dev (those run QC too, but on other branches).
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the validated commit

--- a/.github/workflows/release-deploy-to-pypi.yml
+++ b/.github/workflows/release-deploy-to-pypi.yml
@@ -11,33 +11,46 @@ permissions:
 
 jobs:
   publish:
+    # Only release after Quality control SUCCEEDS on main (i.e. a merge to main).
+    # Never on pull requests or on pushes to dev (those run QC too, but on other branches).
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the code
+      - name: Check out the validated commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
 
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env
 
       - name: Extract version from pyproject.toml
-        id: extract_version
-        run: |
-          version=$(poetry version -s)
-          echo "VERSION=$version" >> $GITHUB_ENV
+        run: echo "VERSION=$(poetry version -s)" >> "$GITHUB_ENV"
 
-      - name: Create Git tag if not exists
+      - name: Check whether the release tag already exists
+        id: tag
+        run: |
+          git fetch --tags --quiet
+          if git rev-parse "v${{ env.VERSION }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag v${{ env.VERSION }} already exists - skipping release. Bump the version to publish a new release."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push Git tag
+        if: steps.tag.outputs.exists == 'false'
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          if git rev-parse "v${{ env.VERSION }}" >/dev/null 2>&1; then
-            echo "Tag v${{ env.VERSION }} already exists. Skipping tag creation."
-          else
-            git tag v${{ env.VERSION }}
-            git push origin v${{ env.VERSION }}
-          fi
+          git tag "v${{ env.VERSION }}"
+          git push origin "v${{ env.VERSION }}"
 
       - name: Create GitHub Release
-        id: create_release
+        if: steps.tag.outputs.exists == 'false'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,6 +61,7 @@ jobs:
           prerelease: false
 
       - name: Build and publish to PyPi
+        if: steps.tag.outputs.exists == 'false'
         run: |
           source .venv/bin/activate
           poetry version ${{ env.VERSION }}


### PR DESCRIPTION
Follow-up to #63 (the 0.4.0 release). #63 merged the library changes but **not** the CI fix, because the workflow edits needed the `workflow` token scope. This PR carries only the GitHub Actions changes.

## Why
`release-deploy-to-pypi.yml` and `deploy-docs.yml` triggered on **every** `Quality control` completion (`workflow_run`) with no branch/conclusion filter, so they fired on pull requests and dev pushes. With `main` at an old version this failed at `Create GitHub Release` (`v0.2.5` already exists); after #63 it even auto-published `v0.4.0` from a QC completion rather than from a clean main merge.

## Changes
- **release-deploy-to-pypi.yml**: run only when QC `conclusion == 'success'` and `head_branch == 'main'`; check out the validated commit; skip tag/release/publish cleanly when the tag already exists (no more errors).
- **deploy-docs.yml**: same success-on-`main` guard.
- **quality-control.yml**: also run on `push` to `dev`/`main`; add an informational dev-only `tag-check` that warns when the version already has a tag (never releases).

## Resulting flow
- push to **dev** → QC + tag-check, **no release**
- merge to **main** → QC, then on success → tag + GitHub release + PyPI publish (skipped if the version is unchanged)

No version bump: `0.4.0` is already published, so merging this will not re-release (the guarded workflow skips an existing tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)