### PR TITLE
fix(outliers): rolling iqr/zscore crash + iqr quartiles; add Hampel filter (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to gensor are documented here. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.1]
+
+### Added
+
+- `detect_outliers(method="hampel", ...)`: a Hampel filter, a centred rolling median/MAD spike detector. Being median-based it resists the very spikes it targets, making it a robust default for isolated sensor spikes. Tunable via `window` (centred window size) and `n_sigma` (robust-sigma threshold, default 3.0).
+
+### Fixed
+
+- Rolling `iqr`/`zscore` outlier detection (`detect_outliers(..., rolling=True)`) raised `TypeError: only 0-dimensional arrays can be converted to Python scalars` on NumPy 2.x: the rolling detectors returned a 1-element array where `Series.rolling().apply(raw=True)` requires a scalar. They now return a scalar flag.
+- Non-rolling `iqr` used `np.percentile(data, 0.25)` / `0.75` (the 0.25th/0.75th percentiles, near the minimum) instead of the 25th/75th quartiles, collapsing the bounds and removing the bulk of clean data. It now uses the correct quartiles.
+- Rolling `iqr`/`zscore` no longer drop the leading points whose window is incomplete (their NaN mask was coerced to `True`); those points are now retained.
+
 ## [0.4.0]
 
 ### Added

--- a/gensor/analysis/outliers.py
+++ b/gensor/analysis/outliers.py
@@ -6,6 +6,10 @@ from pandas import Series
 from sklearn.ensemble import IsolationForest
 from sklearn.neighbors import LocalOutlierFactor
 
+# Scale factor that makes the median absolute deviation a consistent estimator
+# of the standard deviation for normally distributed data.
+_MAD_TO_STD = 1.4826
+
 
 class OutlierDetection:
     """Detecting outliers in groundwater timeseries data.
@@ -16,6 +20,7 @@ class OutlierDetection:
     Methods:
         iqr: Use interquartile range (IQR).
         zscore: Use the z-score method.
+        hampel: Use the Hampel filter (rolling median absolute deviation).
         isolation_forest: Using the isolation forest algorithm.
         lof: Using the local outlier factor (LOF) method.
     """
@@ -23,7 +28,7 @@ class OutlierDetection:
     def __init__(
         self,
         data: Series,
-        method: Literal["iqr", "zscore", "isolation_forest", "lof"],
+        method: Literal["iqr", "zscore", "hampel", "isolation_forest", "lof"],
         rolling: bool,
         window: int,
         **kwargs: Any,
@@ -37,9 +42,8 @@ class OutlierDetection:
             "lof": self.lof,
         }
 
-        method_func = FUNCS[method]
-
         if method in ["iqr", "zscore"]:
+            method_func = FUNCS[method]
             # For 'iqr' and 'zscore' methods
             y = (
                 kwargs.get("k", 1.5)
@@ -48,60 +52,67 @@ class OutlierDetection:
             )
             if rolling:
                 roll = data.rolling(window=window)
-                mask = roll.apply(lambda x: method_func(x, y, rolling=True), raw=True)
+                # `raw=True` hands each window to the detector as a plain ndarray
+                # and requires a scalar return (0/1). Windows shorter than
+                # `window` yield NaN; treat those as "not an outlier" so the
+                # leading edge of the series is kept rather than dropped.
+                mask = roll.apply(
+                    lambda x: method_func(x, y, rolling=True), raw=True
+                ).fillna(0)
             else:
                 mask = method_func(data.to_numpy(), y, rolling=False)
 
-            bool_mask = mask.astype(bool)
+            bool_mask = np.asarray(mask).astype(bool)
             bool_mask_series = Series(bool_mask, index=data.index)
             self.outliers = data[bool_mask_series]
 
+        elif method == "hampel":
+            self.outliers = self.hampel(data, window=window, **kwargs)
+
         else:
             # For 'isolation_forest' and 'lof' methods
-            self.outliers = method_func(data, **kwargs)
+            self.outliers = FUNCS[method](data, **kwargs)
 
     @staticmethod
-    def iqr(data: np.ndarray, k: float, rolling: bool) -> np.ndarray:
+    def iqr(data: np.ndarray, k: float, rolling: bool) -> Any:
         """Use interquartile range (IQR).
 
         Parameters:
-            data (pandas.Series): The time series data.
+            data (np.ndarray): The time series data (a window when ``rolling``).
 
         Keyword Args:
             k (float): The multiplier for the IQR to define the range. Defaults to 1.5.
 
         Returns:
-            np.ndarray: Binary mask representing the outliers as 1.
+            When ``rolling`` a scalar flag (1.0 outlier / 0.0 inlier) for the most
+            recent point in the window; otherwise a binary mask marking outliers as 1.
         """
 
-        Q1 = np.percentile(data, 0.25)
-        Q3 = np.percentile(data, 0.75)
+        Q1 = np.percentile(data, 25)
+        Q3 = np.percentile(data, 75)
         IQR = Q3 - Q1
 
         lower_bound = Q1 - k * IQR
         upper_bound = Q3 + k * IQR
 
         if rolling:
-            return (
-                np.array([1])
-                if (data[-1] < lower_bound or data[-1] > upper_bound)
-                else np.array([0])
-            )
+            return 1.0 if (data[-1] < lower_bound or data[-1] > upper_bound) else 0.0
 
         return np.where((data < lower_bound) | (data > upper_bound), 1, 0)
 
     @staticmethod
-    def zscore(data: np.ndarray, threshold: float, rolling: bool) -> np.ndarray:
+    def zscore(data: np.ndarray, threshold: float, rolling: bool) -> Any:
         """Use the z-score method.
 
         Parameters:
-            data (pandas.Series): The time series data.
+            data (np.ndarray): The time series data (a window when ``rolling``).
 
         Keyword Args:
             threshold (float): The threshold for the z-score method. Defaults to 3.0.
 
         Returns:
-            pandas.Series: Binary mask representing outliers.
+            When ``rolling`` a scalar flag (1.0 outlier / 0.0 inlier) for the most
+            recent point in the window; otherwise a binary mask marking outliers as 1.
         """
 
         mean = np.mean(data)
@@ -110,8 +121,43 @@ class OutlierDetection:
         z_scores = np.abs((data - mean) / std_dev)
 
         if rolling:
-            return np.array([1]) if z_scores[-1] > threshold else np.array([0])
+            return 1.0 if z_scores[-1] > threshold else 0.0
         return np.where(z_scores > threshold, 1, 0)
+
+    @staticmethod
+    def hampel(data: Series, window: int, n_sigma: float = 3.0) -> Series:
+        """Use the Hampel filter (rolling median absolute deviation).
+
+        For each point a centred window of size ``window`` is taken; the point is
+        flagged when its absolute deviation from the window median exceeds
+        ``n_sigma`` robust standard deviations, estimated as ``1.4826 * MAD``.
+        Being median/MAD based it is far less sensitive to the very spikes it is
+        meant to catch than the mean/std z-score, which makes it a good default
+        for isolated sensor spikes.
+
+        Parameters:
+            data (pandas.Series): The time series data.
+            window (int): Size of the centred rolling window (in samples).
+
+        Keyword Args:
+            n_sigma (float): Number of robust standard deviations beyond which a
+                point is considered an outlier. Defaults to 3.0.
+
+        Returns:
+            pandas.Series: The subset of ``data`` flagged as outliers.
+        """
+
+        rolling = data.rolling(window=window, center=True, min_periods=1)
+        median = rolling.median()
+        mad = rolling.apply(lambda x: np.median(np.abs(x - np.median(x))), raw=True)
+        threshold = n_sigma * _MAD_TO_STD * mad
+
+        deviation = (data - median).abs()
+        # A zero threshold means the window has no spread; only flag a point when
+        # it actually deviates (deviation > 0), so flat stretches stay intact.
+        outlier_mask = deviation > threshold
+
+        return data[outlier_mask]
 
     def isolation_forest(self, data: Series, **kwargs: Any) -> Series:
         """Using the isolation forest algorithm.

--- a/gensor/core/base.py
+++ b/gensor/core/base.py
@@ -206,7 +206,7 @@ class BaseTimeseries(pyd.BaseModel):
 
     def detect_outliers(
         self: T,
-        method: Literal["iqr", "zscore", "isolation_forest", "lof"],
+        method: Literal["iqr", "zscore", "hampel", "isolation_forest", "lof"],
         rolling: bool = False,
         window: int = 6,
         remove: bool = True,
@@ -215,8 +215,10 @@ class BaseTimeseries(pyd.BaseModel):
         """Detects outliers in the timeseries using the specified method.
 
         Parameters:
-            method (Literal['iqr', 'zscore', 'isolation_forest', 'lof']): The
-                method to use for outlier detection.
+            method (Literal['iqr', 'zscore', 'hampel', 'isolation_forest', 'lof']):
+                The method to use for outlier detection. ``hampel`` is an
+                inherently windowed median/MAD filter and ignores ``rolling``,
+                using ``window`` as its centred window size.
             **kwargs: Additional kewword arguments for OutlierDetection.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gensor"
-version = "0.4.0"
+version = "0.4.1"
 description = "Library for handling groundwater sensor data."
 authors = ["Mateusz Zawadzki <zawadzkimat@outlook.com>"]
 repository = "https://github.com/zawadzkim/gensor"

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -1,0 +1,93 @@
+"""Tests for gensor.analysis.outliers via Timeseries.detect_outliers."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gensor import Timeseries
+
+
+def _make_ts(values: np.ndarray) -> Timeseries:
+    index = pd.date_range("2025-01-01", periods=len(values), freq="h", tz="UTC")
+    series = pd.Series(values, index=index)
+    return Timeseries(
+        ts=series, variable="pressure", unit="cmh2o", location="test", sensor=None
+    )
+
+
+@pytest.fixture
+def clean_with_spikes() -> tuple[Timeseries, list[int]]:
+    """A flat, low-noise series with two large injected spikes."""
+    rng = np.random.default_rng(42)
+    values = rng.normal(100.0, 1.0, size=300)
+    spike_positions = [50, 200]
+    values[spike_positions[0]] = 500.0
+    values[spike_positions[1]] = -300.0
+    return _make_ts(values), spike_positions
+
+
+@pytest.mark.parametrize("method", ["iqr", "zscore", "hampel"])
+@pytest.mark.parametrize("rolling", [False, True])
+def test_detect_outliers_runs_and_keeps_signal(method, rolling, clean_with_spikes):
+    """Every method/mode runs without raising and keeps the bulk of the data.
+
+    Regression test for the rolling iqr/zscore crash
+    ("only 0-dimensional arrays can be converted to Python scalars") caused by
+    the rolling detector returning a 1-element array instead of a scalar.
+    """
+    ts, _ = clean_with_spikes
+    filtered = ts.detect_outliers(method=method, rolling=rolling, window=12)
+
+    # The two spikes are removable; the vast majority of points must survive.
+    assert not filtered.ts.empty
+    assert len(filtered.ts) >= len(ts.ts) - 30
+
+
+def test_iqr_uses_real_quartiles(clean_with_spikes):
+    """Non-rolling IQR must use the 25th/75th percentiles, not 0.25/0.75.
+
+    With the old `np.percentile(data, 0.25/0.75)` bug the bounds collapsed near
+    the minimum and removed the overwhelming majority of clean points.
+    """
+    ts, spikes = clean_with_spikes
+    filtered = ts.detect_outliers(method="iqr", rolling=False, window=12)
+
+    # Only a handful of points should be removed, not hundreds.
+    removed = len(ts.ts) - len(filtered.ts)
+    assert removed <= 15
+    # The injected spikes must be among the removed points.
+    for pos in spikes:
+        assert ts.ts.index[pos] not in filtered.ts.index
+
+
+def test_hampel_flags_spikes_and_keeps_flat_regions(clean_with_spikes):
+    ts, spikes = clean_with_spikes
+    filtered = ts.detect_outliers(method="hampel", window=12, n_sigma=3.0)
+
+    for pos in spikes:
+        assert ts.ts.index[pos] not in filtered.ts.index
+    # A near-flat, spike-free series should lose only the spikes.
+    assert len(filtered.ts) >= len(ts.ts) - 10
+
+
+def test_hampel_keeps_perfectly_flat_series():
+    """A constant series has zero spread; nothing should be flagged."""
+    ts = _make_ts(np.full(100, 42.0))
+    filtered = ts.detect_outliers(method="hampel", window=11)
+    assert len(filtered.ts) == len(ts.ts)
+
+
+def test_rolling_does_not_drop_leading_window(clean_with_spikes):
+    """The leading points (incomplete window -> NaN mask) must be retained."""
+    ts, _ = clean_with_spikes
+    filtered = ts.detect_outliers(method="zscore", rolling=True, window=12)
+    # The very first timestamp is not an outlier and must survive.
+    assert ts.ts.index[0] in filtered.ts.index
+
+
+def test_detect_outliers_marks_without_removing(clean_with_spikes):
+    ts, spikes = clean_with_spikes
+    result = ts.detect_outliers(method="hampel", window=12, remove=False)
+    # remove=False returns the original series but records the outliers.
+    assert len(result.ts) == len(ts.ts)
+    assert len(result.outliers) >= len(spikes)


### PR DESCRIPTION
## Why

PocketWater's outlier-filter middleware failed with `TypeError: only 0-dimensional arrays can be converted to Python scalars` when running **rolling** IQR/Z-score detection. Root-caused to gensor 0.4.0.

## Fixes

- **Rolling crash (NumPy 2.x):** the rolling `iqr`/`zscore` detectors returned a 1-element `np.array([1])`/`np.array([0])`, but `Series.rolling().apply(raw=True)` requires a **scalar** return. Now return scalar `1.0`/`0.0`.
- **IQR quartiles:** non-rolling `iqr` used `np.percentile(data, 0.25)` / `0.75` — the **0.25th/0.75th** percentiles (near the minimum), not the 25th/75th quartiles. The collapsed bounds removed the bulk of clean data (repro: 387/500 clean points removed). Fixed to real quartiles.
- **Leading window:** rolling mode dropped the leading incomplete-window points because their NaN mask coerced to `True`. They are now retained.

## Adds

- **Hampel filter** — `detect_outliers(method="hampel", window=..., n_sigma=3.0)`. Centred rolling median/MAD spike detector; median-based so it resists the spikes it targets. Tunable window + robust-sigma threshold.

## Tests

New `tests/test_outliers.py`: all methods × rolling modes, both regressions, and the Hampel filter. Full suite green (106 passed) locally; `ruff check`/`format` clean.

Bumps version to **0.4.1** (auto-releases to PyPI on merge to `main`).